### PR TITLE
CLIF v2.2.0: Add intermittent_dialysis and output concept tables

### DIFF
--- a/src/content/clif-data-dictionary-2.2.0.md
+++ b/src/content/clif-data-dictionary-2.2.0.md
@@ -409,8 +409,10 @@ A planned future CLIF table that has yet to be used in a federated project. The 
 
 The intake_output table is long form table that captures the times intake and output events were recorded, the type of fluid administered or recorded as "out", and the amount of fluid.
 
+**Notes**:
+- This table is likely to be replaced by separate intake and output tables in a future version. The `output` table is already defined as a concept table in CLIF v2.2.0.
 
-
+\
 **Example**:
 
 | hospitalization_id | intake_dttm                  | fluid_name        | amount | in_out_flag |
@@ -422,6 +424,25 @@ The intake_output table is long form table that captures the times intake and ou
 | 1003              | 2024-01-10 07:45:00+00:00 UTC   | Lactated Ringer's| 600     | 1           |
 | 1003              | 2024-01-10 12:00:00+00:00 UTC   | Drainage        | 200     | 0           |
 
+
+## intermittent_dialysis
+
+The intermittent_dialysis table captures intermittent hemodialysis sessions during hospitalization. 
+
+**Notes**:
+- Each dialysis session will have **multiple rows** (one per recorded measurement)
+
+\
+**Example**:
+
+| hospitalization_id | device_id | recorded_dttm | blood_flow_rate | dialysate_flow_rate | net_ultrafiltration_out |
+|-------------------|-----------|---------------|-----------------|---------------------|-------------------------|
+| 30010001 | HD-A1 | 2024-03-10 08:00:00+00:00 UTC | 250.0 | 500.0 | 0.0 |
+| 30010001 | HD-A1 | 2024-03-10 08:30:00+00:00 UTC | 300.0 | 500.0 | 200.0 |
+| 30010001 | HD-A1 | 2024-03-10 09:00:00+00:00 UTC | 300.0 | 500.0 | 450.0 |
+| 30010001 | HD-A1 | 2024-03-10 11:30:00+00:00 UTC | 0.0 | 0.0 | 1500.0 |
+| 30010002 | HD-B3 | 2024-03-11 07:00:00+00:00 UTC | 200.0 | 400.0 | 0.0 |
+| 30010002 | HD-B3 | 2024-03-11 07:30:00+00:00 UTC | 250.0 | 400.0 | 150.0 |
 
 
 ## key_icu_orders
@@ -460,6 +481,27 @@ This table records the ordering (not administration) of medications. The table i
 | 12350             | 456794       | 2023-10-03 10:00:00+00:00 UTC   | 2023-10-03 18:00:00+00:00 UTC   | 2023-10-03 09:45:00+00:00 UTC   | Heparin 5,000 units SC                                             | heparin        | anticoagulant | active              | ongoing                 | Subcutaneous  | 5000.0   | units        | Every 8 hours | 0   |
 | 12351             | 456795       | 2023-10-03 14:00:00+00:00 UTC   | 2023-10-03 22:00:00+00:00 UTC   | 2023-10-03 13:30:00+00:00 UTC   | Morphine Sulfate 2 mg IV                                           | morphine       | analgesics    | active              | ongoing                 | Intravenous   | 2.0      | mg           | As Needed     | 1   |
 | 12352             | 456796       | 2023-10-03 20:00:00+00:00 UTC   | 2023-10-04 08:00:00+00:00 UTC   | 2023-10-03 19:45:00+00:00 UTC   | Dexamethasone 10 mg IV                                             | dexamethasone  | steroids      | active              | ongoing                 | Intravenous   | 10.0     | mg           | Once Daily    | 0   |
+
+
+## output
+
+The output table captures patient fluid output events during hospitalization. 
+
+**Notes**:
+- `output_volume` must be a positive number in mL
+- Ultrafiltration output from dialysis should reflect **net** ultrafiltration only (do not include removal of replacement fluid in CVVH or CVVHDF)
+
+\
+**Example**:
+
+| hospitalization_id | recorded_dttm | output_name | output_category | output_group | output_volume |
+|-------------------|---------------|-------------|-----------------|--------------|---------------|
+| 40010001 | 2024-04-01 08:00:00+00:00 UTC | Foley catheter | indwelling_urinary_catheter | urine | 350.0 |
+| 40010001 | 2024-04-01 12:00:00+00:00 UTC | Foley catheter | indwelling_urinary_catheter | urine | 275.0 |
+| 40010001 | 2024-04-01 14:30:00+00:00 UTC | JP drain | procedural_drain_other | drains | 50.0 |
+| 40010002 | 2024-04-02 06:00:00+00:00 UTC | NG tube output | orogastric_nasogastric_tube | gi | 120.0 |
+| 40010002 | 2024-04-02 10:00:00+00:00 UTC | Chest tube | chest_tube_temporary | drains | 200.0 |
+| 40010003 | 2024-04-03 09:00:00+00:00 UTC | Emesis | emesis | gi | 75.0 |
 
 
 ## place_based_index

--- a/src/content/v-2-2-0-ddl.sql
+++ b/src/content/v-2-2-0-ddl.sql
@@ -42,6 +42,19 @@ CREATE TABLE crrt_therapy (
   ultrafiltration_out FLOAT COMMENT '{"description": "Net ultrafiltration output (mL/hr)", "permissible": "[0-500](https://github.com/Common-Longitudinal-ICU-data-Format/CLIF/blob/main/outlier-handling/outlier_thresholds_crrt_modes.csv)"}'
 );
 
+-- -----------------------------------------------------
+-- Table: intermittent_dialysis
+-- -----------------------------------------------------
+CREATE TABLE intermittent_dialysis (
+  hospitalization_id VARCHAR COMMENT '{"description": "ID variable for each patient encounter", "permissible": "No restriction"}',
+  device_id VARCHAR COMMENT '{"description": "Unique ID of the individual physical device used.", "permissible": "No restriction"}',
+  recorded_dttm DATETIME COMMENT '{"description": "Timestamp of the recorded measurement during the dialysis session. All datetime variables must be timezone-aware and set to UTC.", "permissible": "Datetime format should be YYYY-MM-DD HH:MM:SS+00:00 (UTC)"}',
+  blood_flow_rate FLOAT COMMENT '{"description": "Blood flow rate in mL/min. The first recorded value can indicate session start time.", "permissible": "Numeric values in mL/min"}',
+  dialysate_flow_rate FLOAT COMMENT '{"description": "Dialysate flow rate in mL/min.", "permissible": "Numeric values in mL/min"}',
+  net_ultrafiltration_out FLOAT COMMENT '{"description": "Net ultrafiltration output in mL.", "permissible": "Numeric values in mL"}',
+  FOREIGN KEY (hospitalization_id) REFERENCES hospitalization(hospitalization_id)
+);
+
 -- -----------------------------------------------------#
 -- Table: ecmo_mcs
 -- -----------------------------------------------------#
@@ -281,6 +294,19 @@ CREATE TABLE intake_output (
   fluid_name VARCHAR COMMENT '{"description": "Name of the fluid administered.", "permissible": "No restriction"}',
   amount DOUBLE COMMENT '{"description": "Amount of fluid administered (in mL)", "permissible": "Numeric values in mL"}',
   in_out_flag INT COMMENT '{"description": "Indicator for intake or output (1 for intake, 0 for output)", "permissible": "0 = Output, 1 = Intake"}'
+);
+
+-- -----------------------------------------------------
+-- Table: output
+-- -----------------------------------------------------
+CREATE TABLE output (
+  hospitalization_id VARCHAR COMMENT '{"description": "ID variable for each patient encounter", "permissible": "No restriction"}',
+  recorded_dttm DATETIME COMMENT '{"description": "Date and time when the output was recorded. All datetime variables must be timezone-aware and set to UTC.", "permissible": "Datetime format should be YYYY-MM-DD HH:MM:SS+00:00 (UTC)"}',
+  output_name VARCHAR COMMENT '{"description": "Name of the fluid recorded as patient output.", "permissible": "Examples: urine, SPC output, emesis"}',
+  output_category VARCHAR COMMENT '{"description": "Maps output_name to a set of permissible output categories.", "permissible": "[List of output categories in CLIF](https://github.com/Common-Longitudinal-ICU-data-Format/CLIF/blob/main/mCIDE/output/clif_output_categories.csv)"}',
+  output_group VARCHAR COMMENT '{"description": "Maps output_category to a smaller set of source groups.", "permissible": "[urine, ultrafiltration, drains, gi, procedure, blood_loss, respiratory, other](https://github.com/Common-Longitudinal-ICU-data-Format/CLIF/blob/main/mCIDE/output/clif_output_groups.csv)"}',
+  output_volume FLOAT COMMENT '{"description": "Volume of output fluid in mL. Must be a positive number.", "permissible": "Numeric. Should not be negative."}',
+  FOREIGN KEY (hospitalization_id) REFERENCES hospitalization(hospitalization_id)
 );
 
 -- -----------------------------------------------------

--- a/src/pages/data-dictionary/change-log.astro
+++ b/src/pages/data-dictionary/change-log.astro
@@ -22,7 +22,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
       >
         <h2 class="text-2xl font-bold text-clif-burgundy mb-4">
           Version 2.2.0
-          <span class="text-lg font-normal text-gray-600">(January 2026)</span>
+          <span class="text-lg font-normal text-gray-600">(February 2026)</span>
           <span class="ml-2 bg-gray-500 text-white text-sm px-3 py-1 rounded-full"
             >Coming Soon</span
           >
@@ -33,7 +33,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
           <summary
             class="cursor-pointer bg-clif-burgundy/5 px-4 py-3 font-semibold text-clif-burgundy hover:bg-clif-burgundy/10 transition-colors"
           >
-            New Tables (3 concept tables added)
+            New Tables (5 concept tables added)
           </summary>
           <div class="overflow-x-auto">
             <table class="min-w-full divide-y divide-gray-200">
@@ -54,6 +54,18 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
                 </tr>
               </thead>
               <tbody class="bg-white divide-y divide-gray-200">
+                <tr>
+                  <td class="px-4 py-3 text-sm font-mono">intermittent_dialysis</td>
+                  <td class="px-4 py-3 text-sm">Concept table capturing intermittent hemodialysis sessions during hospitalization, with per-measurement rows tracking blood flow rate, dialysate flow rate, and net ultrafiltration.</td>
+                  <td class="px-4 py-3 text-sm"><a href="https://github.com/Common-Longitudinal-ICU-data-Format/CLIF/issues/143" class="text-clif-burgundy hover:underline">Issue #143</a></td>
+                  <td class="px-4 py-3 text-sm text-gray-500">Feb 17, 2026</td>
+                </tr>
+                <tr>
+                  <td class="px-4 py-3 text-sm font-mono">output</td>
+                  <td class="px-4 py-3 text-sm">Concept table capturing patient fluid output events during hospitalization, including output name, category, group, and volume in mL.</td>
+                  <td class="px-4 py-3 text-sm"><a href="https://github.com/Common-Longitudinal-ICU-data-Format/CLIF/issues/142" class="text-clif-burgundy hover:underline">Issue #142</a></td>
+                  <td class="px-4 py-3 text-sm text-gray-500">Feb 12, 2026</td>
+                </tr>
                 <tr>
                   <td class="px-4 py-3 text-sm font-mono">validated_diagnosis</td>
                   <td class="px-4 py-3 text-sm">Concept table for clinician-validated diagnostic labels for research purposes. Designed for studies requiring confirmed diagnoses through chart review or consensus adjudication, enabling high-quality phenotyping for research cohorts.</td>
@@ -168,6 +180,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
             </table>
           </div>
         </details>
+
       </section>
 
       <!-- Version 2.1.0 -->

--- a/src/pages/data-dictionary/data-dictionary-2.2.0.astro
+++ b/src/pages/data-dictionary/data-dictionary-2.2.0.astro
@@ -72,7 +72,7 @@ const betaTableNames = [
   'patient_assessments', 'patient_procedures', 'position', 'respiratory_support', 'vitals'
 ];
 const conceptTableNames = [
-  'clinical_notes_facts', 'clinical_notes_text', 'clinical_trial', 'ecmo_mcs', 'intake_output', 'invasive_hemodynamics', 'key_icu_orders', 'medication_orders', 'microbiology_nonculture', 'patient_diagnosis', 'place_based_index',
+  'clinical_notes_facts', 'clinical_notes_text', 'clinical_trial', 'ecmo_mcs', 'intake_output', 'intermittent_dialysis', 'invasive_hemodynamics', 'key_icu_orders', 'medication_orders', 'microbiology_nonculture', 'output', 'patient_diagnosis', 'place_based_index',
   'provider', 'therapy_details', 'transfusion', 'validated_diagnosis'
 ];
 const betaTables = allTables


### PR DESCRIPTION
## Summary
- New **intermittent_dialysis** concept table — captures iHD sessions with time-series measurements ([#143](https://github.com/Common-Longitudinal-ICU-data-Format/CLIF/issues/143))
- New **output** concept table — captures patient fluid output with hierarchical categorization ([#142](https://github.com/Common-Longitudinal-ICU-data-Format/CLIF/issues/142))
- Added deprecation note to `intake_output` table
- Updated changelog for v2.2.0 with all 5 new concept tables and issue links