### PR TITLE
fix(data-dictionary): add HelpChat widget to v3.0.0 page

### DIFF
--- a/src/pages/data-dictionary/data-dictionary-3.0.0.astro
+++ b/src/pages/data-dictionary/data-dictionary-3.0.0.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Badge from '../../components/Badge.astro';
+import HelpChat from '../../components/HelpChat.astro';
 import fs from 'node:fs';
 import path from 'node:path';
 import MarkdownIt from 'markdown-it';
@@ -623,4 +624,14 @@ const conceptSectionHeader = markdownTableSections['Concept_Tables'] || '';
       });
     });
   </script>
+
+  <!-- Help Chat Widget -->
+  <HelpChat
+    githubRepo="clif-consortium/CLIF"
+    defaultAssignee="deetherese"
+    pageName="Data Dictionary 3.0"
+    pageLabel="data-dictionary"
+    tableLabel="Related Table (optional)"
+    tables={[...betaTableNames, ...alphaTableNames, ...conceptTableNames].sort()}
+  />
 </BaseLayout>


### PR DESCRIPTION
## What
Adds the floating "report an issue" help widget (`HelpChat.astro`) to the **Data Dictionary 3.0.0** page.

## Why
The widget was wired into the 2.1.0 data dictionary page but never added to 3.0.0, so the question-mark help button was missing there.

## Change
- Import `HelpChat` in `data-dictionary-3.0.0.astro`
- Render it before `</BaseLayout>`, matching 2.1.0's config (`pageName="Data Dictionary 3.0"`, same repo/assignee), with the table dropdown populated from 3.0.0's beta/alpha/concept table lists

## Verification
- `npm run build` renders the page; built HTML contains the widget markers (`help-chat-toggle`, "Need help? Report an issue", "Data Dictionary 3.0")
- Pre-existing `astro check` type warnings and the post-build image-optimization error are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)