### PR TITLE
docs(data-dictionary): clarify patient_diagnosis holds non-billing IC…

### DIFF
--- a/src/content/clif-data-dictionary-3.0.0.md
+++ b/src/content/clif-data-dictionary-3.0.0.md
@@ -314,7 +314,7 @@ The patient_assessments table captures various assessments performed on patients
 
 ## patient_diagnosis
 
-The `patient_diagnosis` table provides a record of all diagnoses assigned to a patient. 
+The `patient_diagnosis` table provides a record of all diagnoses assigned to a patient. It captures all ICD-10 diagnosis codes that are **not** generated at billing (e.g., problem list, encounter, and medical history diagnoses) — in contrast to `hospital_diagnosis`, which holds the finalized billing codes. 
     
 
 **Example**:


### PR DESCRIPTION
…D-10 codes

Note that patient_diagnosis captures all ICD-10 diagnosis codes not generated at billing (problem list, encounter, medical history), in contrast to hospital_diagnosis which holds the finalized billing codes.