### PR TITLE
feat(portal): member notifications and pending tasks

### DIFF
--- a/migrations/012-notifications.sql
+++ b/migrations/012-notifications.sql
@@ -1,0 +1,30 @@
+-- In-portal notifications for members (/portal/notifications + header bell).
+--
+-- Holds DISCRETE EVENTS delivered to a specific user (a new project run was
+-- filed, a site was nudged to run a project, etc.). Standing obligations
+-- ("your site hasn't run project X", "your profile is incomplete") are NOT
+-- stored here — they are derived live from existing tables by src/lib/tasks.ts,
+-- so they self-heal when the underlying state changes.
+--
+-- One row per (recipient, event). `title`/`link` are pre-rendered so the bell
+-- and inbox render from a single indexed query with no joins. `entity_type` +
+-- `entity_id` support deep-linking and de-duplication.
+--
+-- Apply once:  turso db shell clif-consortium < migrations/012-notifications.sql
+CREATE TABLE IF NOT EXISTS notifications (
+  id           TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type         TEXT NOT NULL,          -- e.g. 'project_run.created', 'project_run.site_nudged'
+  title        TEXT NOT NULL,          -- pre-rendered summary line
+  body         TEXT,                   -- optional detail line
+  link         TEXT,                   -- deep link, e.g. /portal/project-runs
+  entity_type  TEXT,                   -- 'project_run' | 'los_request' | 'site' | ...
+  entity_id    TEXT,                   -- for dedup + deep-linking
+  actor_id     TEXT REFERENCES users(id),  -- who triggered it (nullable = system)
+  read_at      TEXT,
+  created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Bell/inbox query path: newest-first per user, unread cheaply countable.
+CREATE INDEX IF NOT EXISTS idx_notifications_user
+  ON notifications(user_id, read_at, created_at);

--- a/migrations/014-task-dismissals.sql
+++ b/migrations/014-task-dismissals.sql
@@ -1,0 +1,22 @@
+-- Lets a member clear a derived "pending task" when there is genuinely nothing
+-- to do (site details already complete, profile fine as-is). Only site-detail
+-- and profile tasks are dismissible; run-a-project and steering-review tasks are
+-- not (a project you owe is not something you can wave away).
+--
+-- This is NOT a blunt mute. Each row stores a `signature` describing exactly
+-- what was dismissed (which fields were missing, whether the record was stale).
+-- computePendingTasks suppresses a task only while its current signature still
+-- matches the dismissed one -- so if the situation later changes (a new field
+-- goes blank, or the record goes stale again) the signature differs and the
+-- task comes back. You acknowledge a specific state, not the task forever.
+--
+-- One row per (member, task). Re-dismissing updates the signature in place.
+--
+-- Apply once:  turso db shell clif-consortium < migrations/014-task-dismissals.sql
+CREATE TABLE IF NOT EXISTS task_dismissals (
+  user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  task_key     TEXT NOT NULL,            -- matches PendingTask.key, e.g. 'stale_site:<id>' | 'incomplete_profile'
+  signature    TEXT NOT NULL,            -- snapshot of the task's reason; task re-appears when this changes
+  dismissed_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, task_key)
+);

--- a/src/components/layout/Navigation.astro
+++ b/src/components/layout/Navigation.astro
@@ -1,7 +1,9 @@
 ---
 // src/components/layout/Navigation.astro
+import NotificationBell from '../portal/NotificationBell.astro';
+
 interface Props {
-  user?: { email: string; full_name: string | null; avatar_url?: string | null; role: string; is_approved: boolean } | null;
+  user?: { id?: string; email: string; full_name: string | null; avatar_url?: string | null; role: string; is_approved: boolean } | null;
 }
 
 const { user = null } = Astro.props;
@@ -107,6 +109,11 @@ const navItems = [
     >
     </div>
   </div>
+
+  <!-- Notifications bell (approved members only) -->
+  {user && user.is_approved && user.id && (
+    <NotificationBell userId={user.id} />
+  )}
 
   <!-- Members / User Menu -->
   {user ? (
@@ -233,6 +240,19 @@ const navItems = [
       <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
     </svg>
   </button>
+
+  <!-- Mobile notifications link (approved members only) -->
+  {user && user.is_approved && (
+    <a
+      href="/portal/notifications"
+      class="p-1.5 rounded-lg text-gray-700 hover:text-clif-burgundy hover:bg-gray-100 dark:text-white dark:hover:bg-neutral-700 transition-colors"
+      aria-label="Notifications"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" class="w-6 h-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" />
+      </svg>
+    </a>
+  )}
 
   <button
     id="mobile-menu-button"

--- a/src/components/portal/NotificationBell.astro
+++ b/src/components/portal/NotificationBell.astro
@@ -1,0 +1,144 @@
+---
+import { listNotifications, unreadCount } from '../../lib/notifications';
+
+interface Props {
+  userId: string;
+}
+
+const { userId } = Astro.props;
+
+const [items, unread] = await Promise.all([
+  listNotifications(userId, 12),
+  unreadCount(userId),
+]);
+
+function timeAgo(iso: string): string {
+  const then = new Date(iso.includes('T') || iso.includes('Z') ? iso : iso.replace(' ', 'T') + 'Z').getTime();
+  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (secs < 60) return 'just now';
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(then).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+---
+
+<div class="relative" id="notif-bell-root">
+  <button
+    id="notif-bell-btn"
+    class="relative p-2 rounded-lg text-gray-700 hover:text-clif-burgundy hover:bg-gray-100 dark:text-gray-300 dark:hover:text-clif-burgundy dark:hover:bg-neutral-700 transition-colors"
+    aria-label="Notifications"
+    aria-haspopup="true"
+    aria-expanded="false"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" class="w-6 h-6">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" />
+    </svg>
+    <span
+      id="notif-badge"
+      class={`absolute -top-0.5 -right-0.5 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-bold text-white bg-red-500 rounded-full ${unread > 0 ? '' : 'hidden'}`}
+    >{unread > 99 ? '99+' : unread}</span>
+  </button>
+
+  <!-- Dropdown -->
+  <div
+    id="notif-dropdown"
+    class="hidden absolute right-0 top-full mt-2 w-80 max-w-[calc(100vw-2rem)] bg-white dark:bg-neutral-800 rounded-lg shadow-lg border border-gray-200 dark:border-neutral-700 z-50"
+  >
+    <div class="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-neutral-700">
+      <span class="text-sm font-semibold text-gray-900 dark:text-white">Notifications</span>
+      <button id="notif-mark-all" class="text-xs text-clif-burgundy hover:underline">Mark all read</button>
+    </div>
+
+    <div class="max-h-96 overflow-y-auto" id="notif-list">
+      {items.length === 0 ? (
+        <p class="px-4 py-8 text-sm text-center text-gray-500 dark:text-gray-400">You're all caught up.</p>
+      ) : (
+        items.map((n) => (
+          <a
+            href={n.link || '/portal/notifications'}
+            class={`notif-item block px-4 py-3 border-b border-gray-50 dark:border-neutral-700/60 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-colors ${n.read_at ? '' : 'bg-clif-burgundy/[0.04] dark:bg-clif-burgundy/10'}`}
+            data-id={n.id}
+          >
+            <div class="flex items-start gap-2">
+              {!n.read_at && <span class="mt-1.5 w-2 h-2 rounded-full bg-clif-burgundy shrink-0" aria-hidden="true" />}
+              <div class={`min-w-0 ${n.read_at ? 'pl-4' : ''}`}>
+                <p class="text-sm font-medium text-gray-900 dark:text-gray-100 leading-snug">{n.title}</p>
+                {n.body && <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-2">{n.body}</p>}
+                <p class="text-[11px] text-gray-400 dark:text-gray-500 mt-1">{timeAgo(n.created_at)}</p>
+              </div>
+            </div>
+          </a>
+        ))
+      )}
+    </div>
+
+    <a href="/portal/notifications" class="block px-4 py-2.5 text-center text-xs font-medium text-clif-burgundy hover:bg-gray-50 dark:hover:bg-neutral-700/50 border-t border-gray-100 dark:border-neutral-700 rounded-b-lg">
+      View all notifications
+    </a>
+  </div>
+</div>
+
+<script is:inline>
+  (function () {
+    var root = document.getElementById('notif-bell-root');
+    if (!root) return;
+    var btn = document.getElementById('notif-bell-btn');
+    var dropdown = document.getElementById('notif-dropdown');
+    var badge = document.getElementById('notif-badge');
+
+    function close() {
+      dropdown.classList.add('hidden');
+      btn.setAttribute('aria-expanded', 'false');
+    }
+    btn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      var open = dropdown.classList.toggle('hidden');
+      btn.setAttribute('aria-expanded', open ? 'false' : 'true');
+    });
+    document.addEventListener('click', function (e) {
+      if (!root.contains(e.target)) close();
+    });
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') close();
+    });
+
+    function clearBadge() {
+      if (badge) {
+        badge.classList.add('hidden');
+        badge.textContent = '0';
+      }
+    }
+
+    // Mark an item read (fire-and-forget) when the user clicks through to it.
+    document.querySelectorAll('.notif-item').forEach(function (el) {
+      el.addEventListener('click', function () {
+        var id = el.getAttribute('data-id');
+        if (!id) return;
+        navigator.sendBeacon
+          ? navigator.sendBeacon('/api/notifications/mark-read', new Blob([JSON.stringify({ id: id })], { type: 'application/json' }))
+          : fetch('/api/notifications/mark-read', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ id: id }), keepalive: true });
+      });
+    });
+
+    var markAll = document.getElementById('notif-mark-all');
+    if (markAll) {
+      markAll.addEventListener('click', async function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        await fetch('/api/notifications/mark-read', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ all: true }),
+        }).catch(function () {});
+        clearBadge();
+        document.querySelectorAll('#notif-list .notif-item').forEach(function (el) {
+          el.classList.remove('bg-clif-burgundy/[0.04]', 'dark:bg-clif-burgundy/10');
+        });
+      });
+    }
+  })();
+</script>

--- a/src/components/portal/PendingTasks.astro
+++ b/src/components/portal/PendingTasks.astro
@@ -62,9 +62,9 @@ const styles: Record<string, { dot: string; chip: string; label: string }> = {
       <p class="text-sm">You're all caught up — no pending tasks right now.</p>
     </div>
   ) : (
-    <ul class="divide-y divide-gray-100 dark:divide-neutral-700">
-      {tasks.map((t) => (
-        <li>
+    <ul class="divide-y divide-gray-100 dark:divide-neutral-700" id="pending-tasks-list">
+      {tasks.map((t, i) => (
+        <li class={i >= 3 ? 'pending-task-extra hidden' : ''}>
           <a
             href={t.link}
             class="flex items-start gap-3 px-6 py-4 hover:bg-gray-50 dark:hover:bg-neutral-700/40 transition-colors group"
@@ -89,4 +89,32 @@ const styles: Record<string, { dot: string; chip: string; label: string }> = {
       ))}
     </ul>
   )}
+
+  {tasks.length > 3 && (
+    <button
+      type="button"
+      id="pending-tasks-toggle"
+      class="w-full px-6 py-3 text-sm font-medium text-clif-burgundy hover:bg-gray-50 dark:hover:bg-neutral-700/40 border-t border-gray-100 dark:border-neutral-700 transition-colors"
+      aria-expanded="false"
+      data-more={tasks.length - 3}
+    >
+      Show {tasks.length - 3} more
+    </button>
+  )}
 </section>
+
+<script is:inline>
+  (function () {
+    var btn = document.getElementById('pending-tasks-toggle');
+    if (!btn) return;
+    var more = btn.getAttribute('data-more');
+    btn.addEventListener('click', function () {
+      var expanded = btn.getAttribute('aria-expanded') === 'true';
+      document.querySelectorAll('#pending-tasks-list .pending-task-extra').forEach(function (li) {
+        li.classList.toggle('hidden', expanded);
+      });
+      btn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      btn.textContent = expanded ? 'Show ' + more + ' more' : 'Show less';
+    });
+  })();
+</script>

--- a/src/components/portal/PendingTasks.astro
+++ b/src/components/portal/PendingTasks.astro
@@ -20,6 +20,12 @@ try {
 const severityRank: Record<string, number> = { action: 0, warning: 1, info: 2 };
 tasks.sort((a, b) => severityRank[a.severity] - severityRank[b.severity]);
 
+// The header count must match the nav badge (see pendingTaskCount): only tasks
+// the member can actually resolve. `info` rows are awareness items with no
+// action and no dismiss, so counting them would show a number nobody can clear.
+// They still render in the list, tagged Info.
+const actionableCount = tasks.filter((t) => t.severity !== 'info').length;
+
 const styles: Record<string, { dot: string; chip: string; label: string }> = {
   action: {
     dot: 'bg-clif-burgundy',
@@ -47,9 +53,9 @@ const styles: Record<string, { dot: string; chip: string; label: string }> = {
     <h2 id="pending-tasks-heading" class="text-lg font-semibold text-gray-900 dark:text-white">
       Pending tasks
     </h2>
-    {tasks.length > 0 && (
+    {actionableCount > 0 && (
       <span class="inline-flex items-center justify-center min-w-[22px] h-[22px] px-1.5 text-xs font-bold text-white bg-clif-burgundy rounded-full">
-        {tasks.length}
+        {actionableCount}
       </span>
     )}
   </div>

--- a/src/components/portal/PendingTasks.astro
+++ b/src/components/portal/PendingTasks.astro
@@ -1,0 +1,92 @@
+---
+import { computePendingTasks, type PendingTask } from '../../lib/tasks';
+import type { Role } from '../../lib/roles';
+
+interface Props {
+  userId: string;
+  role: Role | string;
+}
+
+const { userId, role } = Astro.props;
+
+let tasks: PendingTask[] = [];
+try {
+  tasks = await computePendingTasks({ id: userId, role });
+} catch {
+  tasks = [];
+}
+
+// Action items float above softer warnings.
+const severityRank: Record<string, number> = { action: 0, warning: 1, info: 2 };
+tasks.sort((a, b) => severityRank[a.severity] - severityRank[b.severity]);
+
+const styles: Record<string, { dot: string; chip: string; label: string }> = {
+  action: {
+    dot: 'bg-clif-burgundy',
+    chip: 'bg-clif-burgundy/10 text-clif-burgundy',
+    label: 'Action needed',
+  },
+  warning: {
+    dot: 'bg-amber-500',
+    chip: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
+    label: 'Review',
+  },
+  info: {
+    dot: 'bg-blue-500',
+    chip: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+    label: 'Info',
+  },
+};
+---
+
+<section
+  class="mb-8 bg-white dark:bg-neutral-800 rounded-xl shadow-sm border border-gray-200 dark:border-neutral-700 overflow-hidden"
+  aria-labelledby="pending-tasks-heading"
+>
+  <div class="flex items-center gap-3 px-6 py-4 border-b border-gray-100 dark:border-neutral-700">
+    <h2 id="pending-tasks-heading" class="text-lg font-semibold text-gray-900 dark:text-white">
+      Pending tasks
+    </h2>
+    {tasks.length > 0 && (
+      <span class="inline-flex items-center justify-center min-w-[22px] h-[22px] px-1.5 text-xs font-bold text-white bg-clif-burgundy rounded-full">
+        {tasks.length}
+      </span>
+    )}
+  </div>
+
+  {tasks.length === 0 ? (
+    <div class="px-6 py-8 flex items-center gap-3 text-gray-500 dark:text-gray-400">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-green-500">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+      </svg>
+      <p class="text-sm">You're all caught up — no pending tasks right now.</p>
+    </div>
+  ) : (
+    <ul class="divide-y divide-gray-100 dark:divide-neutral-700">
+      {tasks.map((t) => (
+        <li>
+          <a
+            href={t.link}
+            class="flex items-start gap-3 px-6 py-4 hover:bg-gray-50 dark:hover:bg-neutral-700/40 transition-colors group"
+          >
+            <span class={`mt-1.5 w-2.5 h-2.5 rounded-full shrink-0 ${styles[t.severity].dot}`} aria-hidden="true" />
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-2 flex-wrap">
+                <p class="text-sm font-medium text-gray-900 dark:text-gray-100 group-hover:text-clif-burgundy transition-colors">
+                  {t.title}
+                </p>
+                <span class={`text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded ${styles[t.severity].chip}`}>
+                  {styles[t.severity].label}
+                </span>
+              </div>
+              {t.detail && <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{t.detail}</p>}
+            </div>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 text-gray-300 dark:text-gray-600 group-hover:text-clif-burgundy shrink-0 mt-1">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+            </svg>
+          </a>
+        </li>
+      ))}
+    </ul>
+  )}
+</section>

--- a/src/components/portal/PendingTasks.astro
+++ b/src/components/portal/PendingTasks.astro
@@ -88,13 +88,13 @@ const styles: Record<string, { dot: string; chip: string; label: string }> = {
           {t.dismissible && (
             <button
               type="button"
-              class="task-dismiss shrink-0 px-3 text-clif-burgundy/70 hover:text-clif-burgundy hover:bg-clif-burgundy/5 dark:hover:bg-clif-burgundy/10 transition-colors"
+              class="task-dismiss shrink-0 flex items-start pt-4 pr-6 pl-1 text-clif-burgundy/70 hover:text-clif-burgundy transition-colors"
               data-key={t.key}
               data-signature={t.signature}
               aria-label="Nothing to change — dismiss this task"
               title="Nothing to change — dismiss"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.2" stroke="currentColor" class="w-5 h-5">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.2" stroke="currentColor" class="w-5 h-5 mt-0.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
               </svg>
             </button>

--- a/src/components/portal/PendingTasks.astro
+++ b/src/components/portal/PendingTasks.astro
@@ -64,10 +64,10 @@ const styles: Record<string, { dot: string; chip: string; label: string }> = {
   ) : (
     <ul class="divide-y divide-gray-100 dark:divide-neutral-700" id="pending-tasks-list">
       {tasks.map((t, i) => (
-        <li class={i >= 3 ? 'pending-task-extra hidden' : ''}>
+        <li class={`pending-task-row flex items-stretch ${i >= 3 ? 'pending-task-extra hidden' : ''}`}>
           <a
             href={t.link}
-            class="flex items-start gap-3 px-6 py-4 hover:bg-gray-50 dark:hover:bg-neutral-700/40 transition-colors group"
+            class="flex items-start gap-3 px-6 py-4 flex-1 min-w-0 hover:bg-gray-50 dark:hover:bg-neutral-700/40 transition-colors group"
           >
             <span class={`mt-1.5 w-2.5 h-2.5 rounded-full shrink-0 ${styles[t.severity].dot}`} aria-hidden="true" />
             <div class="min-w-0 flex-1">
@@ -85,6 +85,20 @@ const styles: Record<string, { dot: string; chip: string; label: string }> = {
               <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
             </svg>
           </a>
+          {t.dismissible && (
+            <button
+              type="button"
+              class="task-dismiss shrink-0 px-3 text-gray-300 hover:text-gray-600 dark:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-neutral-700/40 transition-colors"
+              data-key={t.key}
+              data-signature={t.signature}
+              aria-label="Nothing to change — dismiss this task"
+              title="Nothing to change — dismiss"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" class="w-4 h-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
         </li>
       ))}
     </ul>
@@ -105,16 +119,61 @@ const styles: Record<string, { dot: string; chip: string; label: string }> = {
 
 <script is:inline>
   (function () {
-    var btn = document.getElementById('pending-tasks-toggle');
-    if (!btn) return;
-    var more = btn.getAttribute('data-more');
-    btn.addEventListener('click', function () {
-      var expanded = btn.getAttribute('aria-expanded') === 'true';
-      document.querySelectorAll('#pending-tasks-list .pending-task-extra').forEach(function (li) {
-        li.classList.toggle('hidden', expanded);
+    var toggle = document.getElementById('pending-tasks-toggle');
+    if (toggle) {
+      var more = toggle.getAttribute('data-more');
+      toggle.addEventListener('click', function () {
+        var expanded = toggle.getAttribute('aria-expanded') === 'true';
+        document.querySelectorAll('#pending-tasks-list .pending-task-extra').forEach(function (li) {
+          li.classList.toggle('hidden', expanded);
+        });
+        toggle.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+        toggle.textContent = expanded ? 'Show ' + more + ' more' : 'Show less';
       });
-      btn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-      btn.textContent = expanded ? 'Show ' + more + ' more' : 'Show less';
+    }
+
+    var section = document.querySelector('[aria-labelledby="pending-tasks-heading"]');
+    var list = document.getElementById('pending-tasks-list');
+    var countBadge = document.querySelector('#pending-tasks-heading + span');
+
+    function afterRemoval() {
+      var remaining = list ? list.querySelectorAll('li').length : 0;
+      if (countBadge) {
+        if (remaining > 0) countBadge.textContent = String(remaining);
+        else countBadge.remove();
+      }
+      // Hide the "Show N more" control once nothing is left to reveal.
+      if (toggle && remaining <= 3) toggle.classList.add('hidden');
+      // Nothing left at all — swap in the caught-up state.
+      if (remaining === 0 && section) {
+        if (list) list.remove();
+        if (toggle) toggle.remove();
+        var done = document.createElement('div');
+        done.className = 'px-6 py-8 flex items-center gap-3 text-gray-500 dark:text-gray-400';
+        done.innerHTML =
+          '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-green-500"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" /></svg>' +
+          '<p class="text-sm">You’re all caught up — no pending tasks right now.</p>';
+        section.appendChild(done);
+      }
+    }
+
+    document.querySelectorAll('.task-dismiss').forEach(function (btn) {
+      btn.addEventListener('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var key = btn.getAttribute('data-key');
+        var signature = btn.getAttribute('data-signature');
+        // Fire-and-forget; the row goes immediately so it feels instant.
+        fetch('/api/tasks/dismiss', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key: key, signature: signature }),
+          keepalive: true,
+        }).catch(function () {});
+        var row = btn.closest('li');
+        if (row) row.remove();
+        afterRemoval();
+      });
     });
   })();
 </script>

--- a/src/components/portal/PendingTasks.astro
+++ b/src/components/portal/PendingTasks.astro
@@ -88,13 +88,13 @@ const styles: Record<string, { dot: string; chip: string; label: string }> = {
           {t.dismissible && (
             <button
               type="button"
-              class="task-dismiss shrink-0 px-3 text-gray-300 hover:text-gray-600 dark:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-neutral-700/40 transition-colors"
+              class="task-dismiss shrink-0 px-3 text-clif-burgundy/70 hover:text-clif-burgundy hover:bg-clif-burgundy/5 dark:hover:bg-clif-burgundy/10 transition-colors"
               data-key={t.key}
               data-signature={t.signature}
               aria-label="Nothing to change — dismiss this task"
               title="Nothing to change — dismiss"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" class="w-4 h-4">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.2" stroke="currentColor" class="w-5 h-5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
               </svg>
             </button>

--- a/src/components/portal/PortalNav.astro
+++ b/src/components/portal/PortalNav.astro
@@ -170,10 +170,12 @@ function iconSvg(name: string): string {
     #portal-nav.is-collapsed .admin-count {
       position: absolute;
       margin: 0;
-      top: 0.15rem;
-      right: 0.35rem;
-      width: 1rem;
+      top: -0.35rem;
+      right: 0.05rem;
+      min-width: 1rem;
+      width: auto;
       height: 1rem;
+      padding: 0 0.2rem;
     }
     #portal-nav.is-collapsed .nav-link {
       position: relative;

--- a/src/components/portal/PortalNav.astro
+++ b/src/components/portal/PortalNav.astro
@@ -1,6 +1,7 @@
 ---
 import { getDb } from '../../lib/turso';
 import { unreadCount } from '../../lib/notifications';
+import { pendingTaskCount } from '../../lib/tasks';
 
 interface Props {
   currentPath: string;
@@ -18,11 +19,17 @@ if (isAdmin) {
   } catch {}
 }
 
-// Unread in-app notifications for the current member (for the sidebar badge).
+// Per-member sidebar badges: unread notifications and outstanding pending tasks.
+// The nav renders on every portal page, so both counts are visible everywhere,
+// not just on the pages that own them. Each guards its own failure.
 let unreadNotifs = 0;
-const currentUserId = Astro.locals.user?.id;
-if (currentUserId) {
-  unreadNotifs = await unreadCount(currentUserId);
+let taskCount = 0;
+const currentUser = Astro.locals.user;
+if (currentUser?.id) {
+  [unreadNotifs, taskCount] = await Promise.all([
+    unreadCount(currentUser.id).catch(() => 0),
+    pendingTaskCount({ id: currentUser.id, role: currentUser.role }).catch(() => 0),
+  ]);
 }
 
 // Dashboard stays pinned first; everything after it is sorted alphabetically by label.
@@ -103,8 +110,11 @@ function iconSvg(name: string): string {
           {item.wip && (
             <span class="wip-badge ml-auto text-[10px] font-semibold uppercase tracking-wide bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 px-1.5 py-0.5 rounded">WIP</span>
           )}
+          {item.href === '/portal' && taskCount > 0 && (
+            <span class="admin-count ml-auto inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-[10px] font-bold text-white bg-clif-burgundy rounded-full" title={`${taskCount} pending task${taskCount === 1 ? '' : 's'}`}>{taskCount > 99 ? '99+' : taskCount}</span>
+          )}
           {item.href === '/portal/notifications' && unreadNotifs > 0 && (
-            <span class="admin-count ml-auto inline-flex items-center justify-center w-5 h-5 text-[10px] font-bold text-white bg-red-500 rounded-full">{unreadNotifs > 99 ? '99+' : unreadNotifs}</span>
+            <span class="admin-count ml-auto inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-[10px] font-bold text-white bg-red-500 rounded-full" title={`${unreadNotifs} unread notification${unreadNotifs === 1 ? '' : 's'}`}>{unreadNotifs > 99 ? '99+' : unreadNotifs}</span>
           )}
         </a>
       </li>

--- a/src/components/portal/PortalNav.astro
+++ b/src/components/portal/PortalNav.astro
@@ -1,5 +1,6 @@
 ---
 import { getDb } from '../../lib/turso';
+import { unreadCount } from '../../lib/notifications';
 
 interface Props {
   currentPath: string;
@@ -17,6 +18,13 @@ if (isAdmin) {
   } catch {}
 }
 
+// Unread in-app notifications for the current member (for the sidebar badge).
+let unreadNotifs = 0;
+const currentUserId = Astro.locals.user?.id;
+if (currentUserId) {
+  unreadNotifs = await unreadCount(currentUserId);
+}
+
 // Dashboard stays pinned first; everything after it is sorted alphabetically by label.
 const portalItems = [
   { label: 'Dashboard', href: '/portal', icon: 'grid', wip: false },
@@ -25,6 +33,7 @@ const portalItems = [
   { label: 'Letter of Support Tracker', href: '/portal/los-requests', icon: 'document', wip: false },
   { label: 'Manuscript Tracker', href: '/portal/status', icon: 'check-circle', wip: false },
   { label: 'Member Directory', href: '/portal/directory', icon: 'users', wip: false },
+  { label: 'Notifications', href: '/portal/notifications', icon: 'bell', wip: false },
   { label: 'Project Run Tracker', href: '/portal/project-runs', icon: 'check-circle', wip: false },
   { label: 'Secure Masking', href: '/portal/crypto', icon: 'lock', wip: false },
   { label: 'Site Details', href: '/portal/site-details', icon: 'building', wip: false },
@@ -48,6 +57,7 @@ const ICON_PATHS: Record<string, string> = {
   building: 'M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21',
   ballot: 'M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25Z',
   shield: 'M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z',
+  bell: 'M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0',
 };
 
 function iconSvg(name: string): string {
@@ -92,6 +102,9 @@ function iconSvg(name: string): string {
           <span class="nav-label">{item.label}</span>
           {item.wip && (
             <span class="wip-badge ml-auto text-[10px] font-semibold uppercase tracking-wide bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 px-1.5 py-0.5 rounded">WIP</span>
+          )}
+          {item.href === '/portal/notifications' && unreadNotifs > 0 && (
+            <span class="admin-count ml-auto inline-flex items-center justify-center w-5 h-5 text-[10px] font-bold text-white bg-red-500 rounded-full">{unreadNotifs > 99 ? '99+' : unreadNotifs}</span>
           )}
         </a>
       </li>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -174,6 +174,44 @@ export function buildProjectRunNotificationEmail(
 </html>`.trim();
 }
 
+export function buildProjectRunNudgeEmail(
+  siteName: string,
+  projectTitle: string,
+  deadline: string | null,
+  projectUrl: string,
+): string {
+  const deadlineBlock = deadline
+    ? `<p style="margin: 16px 0;"><strong>Deadline to upload results to Box:</strong> ${formatDeadline(deadline)}</p>`
+    : '';
+  return `
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; color: #333;">
+  <div style="border-bottom: 3px solid #8B1538; padding-bottom: 16px; margin-bottom: 24px;">
+    <h1 style="color: #8B1538; font-size: 20px; margin: 0;">CLIF Consortium</h1>
+  </div>
+
+  <p><strong>Reminder:</strong> your site <strong>${escapeHtml(siteName)}</strong> has not yet run the following project:</p>
+
+  <h2 style="font-size: 18px; color: #111; margin: 16px 0 8px;">${escapeHtml(projectTitle)}</h2>
+  ${deadlineBlock}
+
+  <div style="margin: 28px 0;">
+    <a href="${projectUrl}" style="background-color: #8B1538; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: 600; display: inline-block;">
+      View Project Run
+    </a>
+  </div>
+
+  <p style="color: #666; font-size: 14px;">Once your site has run it, check it off on the Project Run Tracker. Questions? Reach out to <a href="mailto:clif_consortium@uchicago.edu">clif_consortium@uchicago.edu</a>.</p>
+
+  <div style="border-top: 1px solid #e5e7eb; margin-top: 32px; padding-top: 16px; font-size: 12px; color: #9ca3af;">
+    CLIF Consortium &middot; Common Longitudinal ICU Data Format
+  </div>
+</body>
+</html>`.trim();
+}
+
 export function buildProposalReminderEmail(
   title: string,
   deadline: string,

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,164 @@
+import { getDb } from './turso';
+import { sendEmail } from './email';
+import { loginEmailsByUser } from './recipient-emails';
+
+/**
+ * Stored, discrete-event notifications for members (the header bell + the
+ * /portal/notifications inbox). Standing obligations are derived separately in
+ * ./tasks — this module only handles events that "happened" and their per-user
+ * read state.
+ */
+
+export interface NotificationRow {
+  id: string;
+  type: string;
+  title: string;
+  body: string | null;
+  link: string | null;
+  entity_type: string | null;
+  entity_id: string | null;
+  actor_id: string | null;
+  read_at: string | null;
+  created_at: string;
+}
+
+export interface NotificationInput {
+  type: string;
+  title: string;
+  body?: string | null;
+  link?: string | null;
+  entityType?: string | null;
+  entityId?: string | null;
+  actorId?: string | null;
+}
+
+/** Optional email side-channel for a fan-out. */
+export interface EmailPayload {
+  subject: string;
+  html: string;
+}
+
+/**
+ * Insert one in-app notification for a single recipient. Returns the new id, or
+ * null on failure (callers treat notifications as best-effort).
+ */
+export async function createNotification(
+  userId: string,
+  n: NotificationInput,
+): Promise<string | null> {
+  const db = getDb();
+  try {
+    const res = await db.execute({
+      sql: `INSERT INTO notifications
+              (user_id, type, title, body, link, entity_type, entity_id, actor_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            RETURNING id`,
+      args: [
+        userId,
+        n.type,
+        n.title,
+        n.body ?? null,
+        n.link ?? null,
+        n.entityType ?? null,
+        n.entityId ?? null,
+        n.actorId ?? null,
+      ],
+    });
+    return (res.rows[0]?.id as string) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Deliver the same notification to many recipients at once (in-app rows), and
+ * optionally email each of them at every address they sign in with. The actor
+ * is never notified about their own action. Fire-and-forget friendly: a bad
+ * address or a single failed insert never rejects the batch.
+ *
+ * @returns the number of distinct users notified in-app
+ */
+export async function fanOutNotification(
+  userIds: string[],
+  n: NotificationInput,
+  email?: EmailPayload,
+): Promise<number> {
+  const recipients = Array.from(new Set(userIds)).filter(
+    (id) => id && id !== n.actorId,
+  );
+  if (recipients.length === 0) return 0;
+
+  // In-app rows — one per recipient.
+  await Promise.all(recipients.map((id) => createNotification(id, n)));
+
+  // Optional email — reach each member at all of their linked addresses.
+  if (email) {
+    const emailMap = await loginEmailsByUser(recipients);
+    const sends: Promise<unknown>[] = [];
+    for (const id of recipients) {
+      for (const addr of emailMap.get(id) ?? []) {
+        sends.push(
+          sendEmail(addr, email.subject, email.html).catch(() => {
+            /* one bad address shouldn't fail the batch */
+          }),
+        );
+      }
+    }
+    await Promise.all(sends);
+  }
+
+  return recipients.length;
+}
+
+/** Count a member's unread notifications (for the bell badge). */
+export async function unreadCount(userId: string): Promise<number> {
+  const db = getDb();
+  try {
+    const res = await db.execute({
+      sql: 'SELECT COUNT(*) AS cnt FROM notifications WHERE user_id = ? AND read_at IS NULL',
+      args: [userId],
+    });
+    return Number(res.rows[0]?.cnt) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** A member's most recent notifications, newest first. */
+export async function listNotifications(
+  userId: string,
+  limit = 30,
+): Promise<NotificationRow[]> {
+  const db = getDb();
+  try {
+    const res = await db.execute({
+      sql: `SELECT id, type, title, body, link, entity_type, entity_id, actor_id, read_at, created_at
+            FROM notifications
+            WHERE user_id = ?
+            ORDER BY created_at DESC
+            LIMIT ?`,
+      args: [userId, limit],
+    });
+    return res.rows as unknown as NotificationRow[];
+  } catch {
+    return [];
+  }
+}
+
+/** Mark a single notification read (scoped to its owner). */
+export async function markRead(userId: string, id: string): Promise<void> {
+  const db = getDb();
+  await db.execute({
+    sql: 'UPDATE notifications SET read_at = ? WHERE id = ? AND user_id = ? AND read_at IS NULL',
+    args: [new Date().toISOString(), id, userId],
+  });
+}
+
+/** Mark all of a member's notifications read. */
+export async function markAllRead(userId: string): Promise<void> {
+  const db = getDb();
+  await db.execute({
+    sql: 'UPDATE notifications SET read_at = ? WHERE user_id = ? AND read_at IS NULL',
+    args: [new Date().toISOString(), userId],
+  });
+}

--- a/src/lib/notify-project-run.ts
+++ b/src/lib/notify-project-run.ts
@@ -1,6 +1,7 @@
 import { getDb } from './turso';
 import { sendEmail, buildProjectRunNotificationEmail } from './email';
 import { loginEmailsByUser } from './recipient-emails';
+import { createNotification } from './notifications';
 
 /**
  * Email the "a new project run is ready" notification to every approved
@@ -54,6 +55,20 @@ export async function notifyProjectRunReady(
   );
   const subject = `New CLIF project run ready: ${p.title as string}`;
 
+  // In-app notification for the bell/inbox — one per recipient, best-effort.
+  const title = p.title as string;
+  const inApp = recipients.map((r) =>
+    createNotification(r.id, {
+      type: 'project_run.created',
+      title: `New project run ready: ${title}`,
+      body: (p.description as string) || null,
+      link: projectUrl,
+      entityType: 'project_run',
+      entityId: projectId,
+      actorId: opts.excludeUserId ?? null,
+    }),
+  );
+
   // Reach each member at every address they sign in with, not just the primary.
   const emailMap = await loginEmailsByUser(recipients.map((r) => r.id));
   const sends: Promise<unknown>[] = [];
@@ -66,7 +81,7 @@ export async function notifyProjectRunReady(
       );
     }
   }
-  await Promise.all(sends);
+  await Promise.all([...inApp, ...sends]);
 
   return { sent: recipients.length };
 }

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -1,0 +1,229 @@
+import { getDb } from './turso';
+import type { Role } from './roles';
+
+/**
+ * Derived "pending tasks" for a member — standing obligations computed live from
+ * existing tables (project runs, site details, profile, LOS requests). Nothing
+ * is stored: a task disappears the moment its underlying state is resolved (a
+ * box is checked, a field is filled, a request is approved), so there is no
+ * read/dismiss bookkeeping to drift out of sync. Discrete one-off events live in
+ * ./notifications instead.
+ */
+
+export type TaskSeverity = 'action' | 'warning' | 'info';
+
+export interface PendingTask {
+  key: string; // stable id for de-dup / keys
+  kind: 'run_project' | 'stale_site' | 'incomplete_profile' | 'los_review';
+  title: string;
+  detail?: string;
+  link: string;
+  severity: TaskSeverity;
+}
+
+// A site record is considered "stale" if it hasn't been touched in this long OR
+// is missing any required field (the user picked BOTH signals).
+const STALE_MONTHS = 6;
+const SITE_REQUIRED_FIELDS = [
+  'data_source',
+  'source_data_date_range',
+  'irb_number',
+  'cohort_inclusion_criteria',
+] as const;
+// Core profile fields every member should keep current.
+const PROFILE_REQUIRED_FIELDS = ['full_name', 'institution', 'work_email'] as const;
+
+interface TaskUser {
+  id: string;
+  role: Role | string;
+}
+
+function isOlderThanMonths(iso: string | null, months: number): boolean {
+  if (!iso) return true; // never updated counts as stale
+  const then = new Date(iso).getTime();
+  if (isNaN(then)) return true;
+  const cutoff = Date.now() - months * 30 * 24 * 60 * 60 * 1000;
+  return then < cutoff;
+}
+
+/**
+ * Has a deadline already passed? A date-only deadline ("2026-07-16") is due at
+ * the END of that day, so it only counts as past once the day is over. No
+ * deadline is never past (unlike `isOlderThanMonths`, where a missing timestamp
+ * means "never updated" and so counts as stale).
+ */
+function isPast(iso: string | null): boolean {
+  if (!iso) return false;
+  const due = new Date(iso.length <= 10 ? iso + 'T23:59:59Z' : iso).getTime();
+  return !isNaN(due) && due < Date.now();
+}
+
+function isBlank(v: unknown): boolean {
+  return v === null || v === undefined || (typeof v === 'string' && v.trim() === '');
+}
+
+/**
+ * Compute every pending task for a member. Safe to call on any portal request;
+ * each sub-query is guarded so one failing check never breaks the panel.
+ */
+export async function computePendingTasks(user: TaskUser): Promise<PendingTask[]> {
+  const db = getDb();
+  const tasks: PendingTask[] = [];
+
+  // Which sites is this member responsible for? (admins are not implicitly
+  // responsible for every site — responsibility comes from site_editors.)
+  let siteIds: string[] = [];
+  try {
+    const res = await db.execute({
+      sql: 'SELECT site_id FROM site_editors WHERE user_id = ?',
+      args: [user.id],
+    });
+    siteIds = (res.rows as any[]).map((r) => r.site_id as string);
+  } catch {
+    siteIds = [];
+  }
+
+  // --- 1. Run an open project at a site you edit ------------------------------
+  if (siteIds.length > 0) {
+    try {
+      const placeholders = siteIds.map(() => '?').join(', ');
+      const res = await db.execute({
+        sql: `SELECT p.id AS project_id, p.title, p.results_deadline,
+                     sd.id AS site_id, sd.site_name
+              FROM project_runs p
+              CROSS JOIN site_details sd
+              LEFT JOIN project_run_sites prs
+                     ON prs.project_id = p.id AND prs.site_id = sd.id
+              WHERE p.status = 'open'
+                AND sd.id IN (${placeholders})
+                AND COALESCE(prs.has_run, 0) = 0
+              ORDER BY p.results_deadline IS NULL, p.results_deadline ASC`,
+        args: siteIds,
+      });
+      for (const r of res.rows as any[]) {
+        const deadline = r.results_deadline as string | null;
+        tasks.push({
+          key: `run_project:${r.project_id}:${r.site_id}`,
+          kind: 'run_project',
+          title: `Run "${r.title}" for ${r.site_name}`,
+          detail: !deadline
+            ? undefined
+            : isPast(deadline)
+              ? `Overdue — results were due ${formatDate(deadline)}`
+              : `Results due ${formatDate(deadline)}`,
+          link: '/portal/project-runs',
+          // Running an open project is always an action item; the query orders
+          // by deadline (soonest first, undated last) and the severity sort is
+          // stable, so overdue rows stay at the top of the panel.
+          severity: 'action',
+        });
+      }
+    } catch {
+      /* skip this check on error */
+    }
+  }
+
+  // --- 2. Update stale / incomplete site details -----------------------------
+  if (siteIds.length > 0) {
+    try {
+      const placeholders = siteIds.map(() => '?').join(', ');
+      const cols = ['id', 'site_name', 'updated_at', ...SITE_REQUIRED_FIELDS].join(', ');
+      const res = await db.execute({
+        sql: `SELECT ${cols} FROM site_details WHERE id IN (${placeholders})`,
+        args: siteIds,
+      });
+      for (const r of res.rows as any[]) {
+        const missing = SITE_REQUIRED_FIELDS.filter((f) => isBlank(r[f]));
+        const stale = isOlderThanMonths(r.updated_at as string | null, STALE_MONTHS);
+        if (missing.length === 0 && !stale) continue;
+        const detail =
+          missing.length > 0
+            ? `Missing: ${missing.map(prettyField).join(', ')}`
+            : `Not updated since ${formatDate(r.updated_at as string)}`;
+        tasks.push({
+          key: `stale_site:${r.id}`,
+          kind: 'stale_site',
+          title: `Review site details for ${r.site_name}`,
+          detail,
+          link: '/portal/site-details',
+          severity: missing.length > 0 ? 'action' : 'warning',
+        });
+      }
+    } catch {
+      /* skip */
+    }
+  }
+
+  // --- 3. Complete your own member profile -----------------------------------
+  try {
+    const cols = PROFILE_REQUIRED_FIELDS.join(', ');
+    const res = await db.execute({
+      sql: `SELECT ${cols} FROM users WHERE id = ?`,
+      args: [user.id],
+    });
+    const row = res.rows[0] as any;
+    if (row) {
+      const missing = PROFILE_REQUIRED_FIELDS.filter((f) => isBlank(row[f]));
+      if (missing.length > 0) {
+        tasks.push({
+          key: 'incomplete_profile',
+          kind: 'incomplete_profile',
+          title: 'Complete your member profile',
+          detail: `Missing: ${missing.map(prettyField).join(', ')}`,
+          link: `/portal/members/${user.id}`,
+          severity: 'action',
+        });
+      }
+    }
+  } catch {
+    /* skip */
+  }
+
+  // --- 4. Letters of support awaiting your approval (steering / admin) --------
+  if (user.role === 'steering' || user.role === 'admin') {
+    try {
+      const res = await db.execute({
+        sql: `SELECT id, grant_title, grant_deadline FROM los_requests WHERE status = 'pending'`,
+        args: [],
+      });
+      for (const r of res.rows as any[]) {
+        const deadline = r.grant_deadline as string | null;
+        tasks.push({
+          key: `los_review:${r.id}`,
+          kind: 'los_review',
+          title: `Review letter of support: ${r.grant_title}`,
+          detail: deadline ? `Grant deadline ${formatDate(deadline)}` : 'Awaiting steering approval',
+          link: '/portal/los-requests',
+          severity: 'action',
+        });
+      }
+    } catch {
+      /* skip */
+    }
+  }
+
+  return tasks;
+}
+
+/** Lightweight count for badges — avoids building full task objects downstream. */
+export async function pendingTaskCount(user: TaskUser): Promise<number> {
+  return (await computePendingTasks(user)).length;
+}
+
+function prettyField(f: string): string {
+  return f
+    .replace(/_/g, ' ')
+    .replace(/\birb\b/i, 'IRB')
+    .replace(/^\w/, (c) => c.toUpperCase());
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr.length <= 10 ? dateStr + 'T12:00:00Z' : dateStr);
+  if (isNaN(d.getTime())) return dateStr;
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -88,44 +88,96 @@ export async function computePendingTasks(user: TaskUser): Promise<PendingTask[]
     siteIds = [];
   }
 
-  // --- 1. Run an open project at a site you edit ------------------------------
-  if (siteIds.length > 0) {
-    try {
-      const placeholders = siteIds.map(() => '?').join(', ');
-      const res = await db.execute({
-        sql: `SELECT p.id AS project_id, p.title, p.results_deadline,
-                     sd.id AS site_id, sd.site_name
-              FROM project_runs p
-              CROSS JOIN site_details sd
-              LEFT JOIN project_run_sites prs
-                     ON prs.project_id = p.id AND prs.site_id = sd.id
-              WHERE p.status = 'open'
-                AND sd.id IN (${placeholders})
-                AND COALESCE(prs.has_run, 0) = 0
-              ORDER BY p.results_deadline IS NULL, p.results_deadline ASC`,
-        args: siteIds,
-      });
-      for (const r of res.rows as any[]) {
-        const deadline = r.results_deadline as string | null;
-        tasks.push({
-          key: `run_project:${r.project_id}:${r.site_id}`,
-          kind: 'run_project',
-          title: `Run "${r.title}" for ${r.site_name}`,
-          detail: !deadline
-            ? undefined
-            : isPast(deadline)
-              ? `Overdue — results were due ${formatDate(deadline)}`
-              : `Results due ${formatDate(deadline)}`,
-          link: '/portal/project-runs',
-          // Running an open project is always an action item; the query orders
-          // by deadline (soonest first, undated last) and the severity sort is
-          // stable, so overdue rows stay at the top of the panel.
-          severity: 'action',
+  // --- 1. Open project runs ---------------------------------------------------
+  // Every member sees each open run. A site editor whose site still owes the run
+  // gets an actionable "run it for your site" task (one per owing site). Everyone
+  // else gets a lower-key info task with the run's progress, so open runs are
+  // visible on every dashboard — not just editors'.
+  try {
+    const openRuns = (await db.execute(
+      `SELECT id, title, results_deadline FROM project_runs
+       WHERE status = 'open'
+       ORDER BY results_deadline IS NULL, results_deadline ASC`,
+    )).rows as any[];
+
+    if (openRuns.length > 0) {
+      const totalSites =
+        Number((await db.execute('SELECT COUNT(*) AS c FROM site_details')).rows[0].c) || 0;
+
+      // How many sites have run each project (for the info task's progress line).
+      const ranByProject = new Map<string, number>();
+      const ranRes = await db.execute(
+        'SELECT project_id, COUNT(*) AS c FROM project_run_sites WHERE has_run = 1 GROUP BY project_id',
+      );
+      for (const r of ranRes.rows as any[]) ranByProject.set(r.project_id as string, Number(r.c));
+
+      // Which of THIS member's sites still owe which project.
+      const owedByProject = new Map<string, { site_id: string; site_name: string }[]>();
+      if (siteIds.length > 0) {
+        const placeholders = siteIds.map(() => '?').join(', ');
+        const res = await db.execute({
+          sql: `SELECT p.id AS project_id, sd.id AS site_id, sd.site_name
+                FROM project_runs p
+                CROSS JOIN site_details sd
+                LEFT JOIN project_run_sites prs ON prs.project_id = p.id AND prs.site_id = sd.id
+                WHERE p.status = 'open' AND sd.id IN (${placeholders}) AND COALESCE(prs.has_run, 0) = 0`,
+          args: siteIds,
         });
+        for (const r of res.rows as any[]) {
+          const arr = owedByProject.get(r.project_id as string) ?? [];
+          arr.push({ site_id: r.site_id as string, site_name: r.site_name as string });
+          owedByProject.set(r.project_id as string, arr);
+        }
       }
-    } catch {
-      /* skip this check on error */
+
+      for (const p of openRuns) {
+        const projectId = p.id as string;
+        const title = p.title as string;
+        const deadline = (p.results_deadline as string) || null;
+        const mine = owedByProject.get(projectId);
+
+        if (mine && mine.length > 0) {
+          // Actionable: this member edits sites that still owe the run.
+          for (const s of mine) {
+            tasks.push({
+              key: `run_project:${projectId}:${s.site_id}`,
+              kind: 'run_project',
+              title: `Run "${title}" for ${s.site_name}`,
+              detail: !deadline
+                ? undefined
+                : isPast(deadline)
+                  ? `Overdue — results were due ${formatDate(deadline)}`
+                  : `Results due ${formatDate(deadline)}`,
+              link: '/portal/project-runs',
+              severity: 'action',
+            });
+          }
+        } else {
+          // Awareness only: shown to members with no actionable stake in this run
+          // (not a site editor, or their sites already ran it).
+          const ran = ranByProject.get(projectId) ?? 0;
+          tasks.push({
+            key: `run_project_info:${projectId}`,
+            kind: 'run_project',
+            title: `Open project run: ${title}`,
+            detail: [
+              `${ran}/${totalSites} sites have run this`,
+              deadline
+                ? isPast(deadline)
+                  ? `overdue ${formatDate(deadline)}`
+                  : `due ${formatDate(deadline)}`
+                : null,
+            ]
+              .filter(Boolean)
+              .join(' · '),
+            link: '/portal/project-runs',
+            severity: 'info',
+          });
+        }
+      }
     }
+  } catch {
+    /* skip this check on error */
   }
 
   // --- 2. Update stale / incomplete site details -----------------------------

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -108,7 +108,11 @@ export async function computePendingTasks(user: TaskUser): Promise<PendingTask[]
       args: [user.id],
     });
     siteIds = (res.rows as any[]).map((r) => r.site_id as string);
-  } catch {
+  } catch (e) {
+    // Each section below degrades to "no tasks" rather than breaking the panel.
+    // Log it: a missing task is indistinguishable from a resolved one, so a
+    // silent failure here is invisible by construction.
+    console.error('[tasks] site_editors lookup failed', e);
     siteIds = [];
   }
 
@@ -200,8 +204,8 @@ export async function computePendingTasks(user: TaskUser): Promise<PendingTask[]
         }
       }
     }
-  } catch {
-    /* skip this check on error */
+  } catch (e) {
+    console.error('[tasks] open project-run check failed', e);
   }
 
   // --- 2. Update stale / incomplete site details -----------------------------
@@ -237,8 +241,8 @@ export async function computePendingTasks(user: TaskUser): Promise<PendingTask[]
           signature: `m:${missing.slice().sort().join(',')}|s:${stale ? 1 : 0}`,
         });
       }
-    } catch {
-      /* skip */
+    } catch (e) {
+      console.error('[tasks] site-details check failed', e);
     }
   }
 
@@ -265,8 +269,8 @@ export async function computePendingTasks(user: TaskUser): Promise<PendingTask[]
         });
       }
     }
-  } catch {
-    /* skip */
+  } catch (e) {
+    console.error('[tasks] profile-completeness check failed', e);
   }
 
   // --- 4. Letters of support awaiting your approval (steering / admin) --------
@@ -287,8 +291,8 @@ export async function computePendingTasks(user: TaskUser): Promise<PendingTask[]
           severity: 'action',
         });
       }
-    } catch {
-      /* skip */
+    } catch (e) {
+      console.error('[tasks] letter-of-support check failed', e);
     }
   }
 
@@ -302,16 +306,27 @@ export async function computePendingTasks(user: TaskUser): Promise<PendingTask[]
       args: [user.id],
     });
     for (const r of res.rows as any[]) dismissed.set(r.task_key as string, r.signature as string);
-  } catch {
-    /* no dismissals table / query failed — show everything */
+  } catch (e) {
+    // Showing everything is the safe failure here — better a task the member
+    // already waved away than a silently suppressed one.
+    console.error('[tasks] dismissal lookup failed — showing all tasks', e);
   }
 
   return tasks.filter((t) => !(t.dismissible && dismissed.get(t.key) === t.signature));
 }
 
-/** Lightweight count for badges — avoids building full task objects downstream. */
+/**
+ * Count for the nav badge: only tasks the member can actually resolve.
+ *
+ * `info` tasks (an open run the member has no stake in) carry no action and
+ * cannot be dismissed, so counting them leaves members with a badge they are
+ * powerless to clear — and a badge that never reaches zero stops being read as
+ * "you have work", taking the actionable items down with it. They still render
+ * in the list; they just don't inflate the count.
+ */
 export async function pendingTaskCount(user: TaskUser): Promise<number> {
-  return (await computePendingTasks(user)).length;
+  const tasks = await computePendingTasks(user);
+  return tasks.filter((t) => t.severity !== 'info').length;
 }
 
 function prettyField(f: string): string {

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -43,10 +43,35 @@ interface TaskUser {
   role: Role | string;
 }
 
+/**
+ * Parse a timestamp out of the database as UTC.
+ *
+ * SQLite's `datetime('now')` (how site_details.updated_at is written) returns
+ * "YYYY-MM-DD HH:MM:SS" — a space separator and no zone marker. `new Date()`
+ * reads that as LOCAL time, so every comparison drifts by the runtime's UTC
+ * offset. Normalize to an explicit UTC instant instead.
+ *
+ * `dateOnlyTime` decides what a bare "YYYY-MM-DD" means: start of day for
+ * staleness, end of day for deadlines, midday for display.
+ * Returns null for missing/unparseable input so each caller decides what that
+ * means, rather than throwing on NULL columns.
+ */
+function parseUtc(value: string | null | undefined, dateOnlyTime = 'T00:00:00Z'): number | null {
+  const s = typeof value === 'string' ? value.trim() : '';
+  if (!s) return null;
+  const iso =
+    s.length <= 10
+      ? s + dateOnlyTime
+      : /([zZ]|[+-]\d{2}:?\d{2})$/.test(s)
+        ? s // already carries a zone — trust it
+        : s.replace(' ', 'T') + 'Z';
+  const t = new Date(iso).getTime();
+  return isNaN(t) ? null : t;
+}
+
 function isOlderThanMonths(iso: string | null, months: number): boolean {
-  if (!iso) return true; // never updated counts as stale
-  const then = new Date(iso).getTime();
-  if (isNaN(then)) return true;
+  const then = parseUtc(iso);
+  if (then === null) return true; // never updated counts as stale
   const cutoff = Date.now() - months * 30 * 24 * 60 * 60 * 1000;
   return then < cutoff;
 }
@@ -58,9 +83,8 @@ function isOlderThanMonths(iso: string | null, months: number): boolean {
  * means "never updated" and so counts as stale).
  */
 function isPast(iso: string | null): boolean {
-  if (!iso) return false;
-  const due = new Date(iso.length <= 10 ? iso + 'T23:59:59Z' : iso).getTime();
-  return !isNaN(due) && due < Date.now();
+  const due = parseUtc(iso, 'T23:59:59Z');
+  return due !== null && due < Date.now();
 }
 
 function isBlank(v: unknown): boolean {
@@ -196,7 +220,9 @@ export async function computePendingTasks(user: TaskUser): Promise<PendingTask[]
         const detail =
           missing.length > 0
             ? `Missing: ${missing.map(prettyField).join(', ')}`
-            : `Not updated since ${formatDate(r.updated_at as string)}`;
+            : r.updated_at
+              ? `Not updated since ${formatDate(r.updated_at as string)}`
+              : 'Never reviewed';
         tasks.push({
           key: `stale_site:${r.id}`,
           kind: 'stale_site',
@@ -295,10 +321,12 @@ function prettyField(f: string): string {
     .replace(/^\w/, (c) => c.toUpperCase());
 }
 
-function formatDate(dateStr: string): string {
-  const d = new Date(dateStr.length <= 10 ? dateStr + 'T12:00:00Z' : dateStr);
-  if (isNaN(d.getTime())) return dateStr;
-  return d.toLocaleDateString('en-US', {
+function formatDate(dateStr: string | null | undefined): string {
+  // Midday UTC for date-only input, so the rendered calendar date can't slip a
+  // day in either direction.
+  const t = parseUtc(dateStr, 'T12:00:00Z');
+  if (t === null) return typeof dateStr === 'string' && dateStr.trim() ? dateStr : 'unknown date';
+  return new Date(t).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -19,6 +19,11 @@ export interface PendingTask {
   detail?: string;
   link: string;
   severity: TaskSeverity;
+  // Site-detail and profile tasks can be dismissed ("nothing to change"); a
+  // project you owe or a review you must do cannot. `signature` captures what
+  // was dismissed so the task returns if that situation later changes.
+  dismissible?: boolean;
+  signature?: string;
 }
 
 // A site record is considered "stale" if it hasn't been touched in this long OR
@@ -147,6 +152,11 @@ export async function computePendingTasks(user: TaskUser): Promise<PendingTask[]
           detail,
           link: '/portal/site-details',
           severity: missing.length > 0 ? 'action' : 'warning',
+          dismissible: true,
+          // Reason snapshot: exactly which fields are missing + whether stale.
+          // A new missing field or a fresh staleness changes this, so a prior
+          // "nothing to change" dismissal no longer applies.
+          signature: `m:${missing.slice().sort().join(',')}|s:${stale ? 1 : 0}`,
         });
       }
     } catch {
@@ -172,6 +182,8 @@ export async function computePendingTasks(user: TaskUser): Promise<PendingTask[]
           detail: `Missing: ${missing.map(prettyField).join(', ')}`,
           link: `/portal/members/${user.id}`,
           severity: 'action',
+          dismissible: true,
+          signature: `m:${missing.slice().sort().join(',')}`,
         });
       }
     }
@@ -202,7 +214,21 @@ export async function computePendingTasks(user: TaskUser): Promise<PendingTask[]
     }
   }
 
-  return tasks;
+  // Drop dismissible tasks the member has waved away — but only while the
+  // dismissed signature still matches. If the situation changed, the signature
+  // differs and the task stays, so nothing important is silenced permanently.
+  const dismissed = new Map<string, string>();
+  try {
+    const res = await db.execute({
+      sql: 'SELECT task_key, signature FROM task_dismissals WHERE user_id = ?',
+      args: [user.id],
+    });
+    for (const r of res.rows as any[]) dismissed.set(r.task_key as string, r.signature as string);
+  } catch {
+    /* no dismissals table / query failed — show everything */
+  }
+
+  return tasks.filter((t) => !(t.dismissible && dismissed.get(t.key) === t.signature));
 }
 
 /** Lightweight count for badges — avoids building full task objects downstream. */

--- a/src/pages/api/admin/assign-site-editor.ts
+++ b/src/pages/api/admin/assign-site-editor.ts
@@ -2,6 +2,7 @@ export const prerender = false;
 
 import type { APIRoute } from 'astro';
 import { getDb } from '../../../lib/turso';
+import { createNotification } from '../../../lib/notifications';
 
 export const POST: APIRoute = async ({ locals, request }) => {
   if (locals.user?.role !== 'admin') {
@@ -23,7 +24,7 @@ export const POST: APIRoute = async ({ locals, request }) => {
   const db = getDb();
 
   // Verify site and user exist
-  const site = await db.execute({ sql: 'SELECT id FROM site_details WHERE id = ?', args: [siteId] });
+  const site = await db.execute({ sql: 'SELECT id, site_name FROM site_details WHERE id = ?', args: [siteId] });
   if (site.rows.length === 0) {
     return new Response(JSON.stringify({ error: 'Site not found' }), {
       status: 404,
@@ -47,6 +48,26 @@ export const POST: APIRoute = async ({ locals, request }) => {
   });
 
   const alreadyAssigned = result.rowsAffected === 0;
+
+  // Ring the assignee's bell — but only on a genuinely new assignment, so a
+  // re-assign no-op (ON CONFLICT DO NOTHING) doesn't spam them. Their derived
+  // pending tasks already reflect the site; this is the discrete "you were
+  // assigned" event. Awaited (not fire-and-forget): on a serverless host the
+  // instance can freeze the moment we respond, so a detached insert might
+  // never commit. createNotification swallows its own errors, so a
+  // notification hiccup still can't fail the assignment.
+  if (!alreadyAssigned) {
+    const siteName = (site.rows[0].site_name as string) || 'a site';
+    await createNotification(userId, {
+      type: 'site_editor.assigned',
+      title: `You've been assigned to review ${siteName}`,
+      body: 'Please review and complete this site’s details in the portal.',
+      link: '/portal/site-details',
+      entityType: 'site',
+      entityId: siteId,
+      actorId: locals.user.id,
+    });
+  }
 
   return new Response(JSON.stringify({ success: true, alreadyAssigned }), {
     status: 200,

--- a/src/pages/api/notifications/index.ts
+++ b/src/pages/api/notifications/index.ts
@@ -1,0 +1,27 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { listNotifications, unreadCount } from '../../../lib/notifications';
+
+// Returns the current member's recent notifications + unread count. Used by the
+// header bell to refresh without a full page load.
+export const GET: APIRoute = async ({ locals }) => {
+  const user = locals.user;
+  if (!user) {
+    return json({ error: 'Unauthorized' }, 401);
+  }
+
+  const [items, unread] = await Promise.all([
+    listNotifications(user.id),
+    unreadCount(user.id),
+  ]);
+
+  return json({ items, unread });
+};
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/pages/api/notifications/mark-read.ts
+++ b/src/pages/api/notifications/mark-read.ts
@@ -1,0 +1,31 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { markRead, markAllRead, unreadCount } from '../../../lib/notifications';
+
+// Mark a single notification read ({ id }) or all of them ({ all: true }).
+export const POST: APIRoute = async ({ locals, request }) => {
+  const user = locals.user;
+  if (!user) {
+    return json({ error: 'Unauthorized' }, 401);
+  }
+
+  const body = await request.json().catch(() => ({}));
+
+  if (body.all) {
+    await markAllRead(user.id);
+  } else if (typeof body.id === 'string' && body.id) {
+    await markRead(user.id, body.id);
+  } else {
+    return json({ error: 'Provide an id or all: true.' }, 400);
+  }
+
+  return json({ success: true, unread: await unreadCount(user.id) });
+};
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/pages/api/project-runs/nudge.ts
+++ b/src/pages/api/project-runs/nudge.ts
@@ -1,0 +1,88 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { getDb } from '../../../lib/turso';
+import { fanOutNotification } from '../../../lib/notifications';
+import { buildProjectRunNudgeEmail } from '../../../lib/email';
+
+// The project run's creator (or an admin) reminds a specific site that it still
+// needs to run the project. Notifies that site's assigned editors in-app and by
+// email. Mirrors the authorization model of /api/project-runs/notify.
+export const POST: APIRoute = async ({ locals, request, url }) => {
+  const user = locals.user;
+  if (!user || !user.is_approved) {
+    return json({ error: 'Forbidden' }, 403);
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const projectId = typeof body.projectId === 'string' ? body.projectId : '';
+  const siteId = typeof body.siteId === 'string' ? body.siteId : '';
+  if (!projectId || !siteId) {
+    return json({ error: 'projectId and siteId are required.' }, 400);
+  }
+
+  const db = getDb();
+
+  const runRes = await db.execute({
+    sql: 'SELECT id, title, results_deadline, created_by FROM project_runs WHERE id = ?',
+    args: [projectId],
+  });
+  if (runRes.rows.length === 0) {
+    return json({ error: 'Project run not found.' }, 404);
+  }
+  const run = runRes.rows[0];
+
+  // Only the creator or an admin may nudge sites for this run.
+  if (user.role !== 'admin' && run.created_by !== user.id) {
+    return json({ error: 'Forbidden' }, 403);
+  }
+
+  const siteRes = await db.execute({
+    sql: 'SELECT id, site_name FROM site_details WHERE id = ?',
+    args: [siteId],
+  });
+  if (siteRes.rows.length === 0) {
+    return json({ error: 'Site not found.' }, 404);
+  }
+  const siteName = siteRes.rows[0].site_name as string;
+
+  // Recipients: everyone assigned to edit this site.
+  const editorsRes = await db.execute({
+    sql: 'SELECT user_id FROM site_editors WHERE site_id = ?',
+    args: [siteId],
+  });
+  const editorIds = (editorsRes.rows as any[]).map((r) => r.user_id as string);
+  if (editorIds.length === 0) {
+    return json({ error: `No data editor is assigned to ${siteName} yet.` }, 400);
+  }
+
+  const projectTitle = run.title as string;
+  const deadline = (run.results_deadline as string) || null;
+  const projectUrl = `${url.origin}/portal/project-runs`;
+
+  const sent = await fanOutNotification(
+    editorIds,
+    {
+      type: 'project_run.site_nudged',
+      title: `Reminder: run "${projectTitle}" for ${siteName}`,
+      body: deadline ? `Results due by the project deadline.` : null,
+      link: projectUrl,
+      entityType: 'project_run',
+      entityId: projectId,
+      actorId: user.id,
+    },
+    {
+      subject: `Reminder to run CLIF project: ${projectTitle}`,
+      html: buildProjectRunNudgeEmail(siteName, projectTitle, deadline, projectUrl),
+    },
+  );
+
+  return json({ success: true, sent });
+};
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/pages/api/project-runs/set-status.ts
+++ b/src/pages/api/project-runs/set-status.ts
@@ -1,0 +1,70 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { getDb } from '../../../lib/turso';
+
+/**
+ * Open/close a project run and nothing else.
+ *
+ * Closing is the routine end-of-lifecycle step — it is what stops an open run
+ * appearing as a pending task on every member's dashboard — so it gets its own
+ * one-column endpoint rather than riding on /update. That route revalidates and
+ * rewrites every field, which would both reject a status-only payload and let a
+ * stale edit form clobber concurrent changes to unrelated columns.
+ *
+ * Same permission rule as /update: the run's creator, or an admin.
+ */
+export const POST: APIRoute = async ({ locals, request }) => {
+  const user = locals.user;
+  if (!user || !user.is_approved) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const body = await request.json();
+  const projectId = typeof body.projectId === 'string' ? body.projectId : '';
+  if (!projectId) {
+    return new Response(JSON.stringify({ error: 'projectId is required.' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (body.status !== 'open' && body.status !== 'closed') {
+    return new Response(JSON.stringify({ error: "status must be 'open' or 'closed'." }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  const status = body.status;
+
+  const db = getDb();
+
+  const existing = await db.execute({
+    sql: 'SELECT created_by FROM project_runs WHERE id = ?',
+    args: [projectId],
+  });
+  if (existing.rows.length === 0) {
+    return new Response(JSON.stringify({ error: 'Not found.' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (user.role !== 'admin' && existing.rows[0].created_by !== user.id) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  await db.execute({
+    sql: "UPDATE project_runs SET status = ?, updated_at = datetime('now') WHERE id = ?",
+    args: [status, projectId],
+  });
+
+  return new Response(JSON.stringify({ ok: true, status }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/api/tasks/dismiss.ts
+++ b/src/pages/api/tasks/dismiss.ts
@@ -1,0 +1,45 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { getDb } from '../../../lib/turso';
+
+// Only site-detail and profile tasks may be dismissed. A run-a-project task or a
+// steering review is a real obligation, not something to wave away, so the
+// server refuses those keys regardless of what the client sends.
+function isDismissible(key: string): boolean {
+  return key.startsWith('stale_site:') || key === 'incomplete_profile';
+}
+
+// Record a "nothing to change" dismissal for one of the current member's tasks.
+// The signature is stored so computePendingTasks can re-surface the task if the
+// underlying situation later changes (see migration 014).
+export const POST: APIRoute = async ({ locals, request }) => {
+  const user = locals.user;
+  if (!user) return json({ error: 'Unauthorized' }, 401);
+
+  const body = await request.json().catch(() => ({}));
+  const key = typeof body.key === 'string' ? body.key : '';
+  const signature = typeof body.signature === 'string' ? body.signature : '';
+  if (!key || !signature) return json({ error: 'key and signature are required.' }, 400);
+  if (!isDismissible(key)) return json({ error: 'This task cannot be dismissed.' }, 400);
+
+  const db = getDb();
+  // Scoped to the caller's own user id — a member can only dismiss their own
+  // tasks. Re-dismissing updates the stored signature in place.
+  await db.execute({
+    sql: `INSERT INTO task_dismissals (user_id, task_key, signature, dismissed_at)
+          VALUES (?, ?, ?, datetime('now'))
+          ON CONFLICT(user_id, task_key)
+          DO UPDATE SET signature = excluded.signature, dismissed_at = excluded.dismissed_at`,
+    args: [user.id, key, signature],
+  });
+
+  return json({ success: true });
+};
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -3,6 +3,7 @@ export const prerender = false;
 
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import PortalNav from '../../components/portal/PortalNav.astro';
+import PendingTasks from '../../components/portal/PendingTasks.astro';
 
 const profile = Astro.locals.user;
 
@@ -35,6 +36,8 @@ const portalSections = [
           </h1>
           <p class="text-gray-600 dark:text-gray-400 mt-2">Access consortium data and resources</p>
         </div>
+
+        {profile?.id && <PendingTasks userId={profile.id} role={profile.role} />}
 
         <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
           {portalSections.map((section) => (

--- a/src/pages/portal/notifications.astro
+++ b/src/pages/portal/notifications.astro
@@ -1,0 +1,121 @@
+---
+export const prerender = false;
+
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PortalNav from '../../components/portal/PortalNav.astro';
+import { listNotifications, unreadCount } from '../../lib/notifications';
+
+const profile = Astro.locals.user!;
+
+const [items, unread] = await Promise.all([
+  listNotifications(profile.id, 100),
+  unreadCount(profile.id),
+]);
+
+function timeAgo(iso: string): string {
+  const then = new Date(iso.includes('T') || iso.includes('Z') ? iso : iso.replace(' ', 'T') + 'Z').getTime();
+  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (secs < 60) return 'just now';
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(then).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+---
+
+<BaseLayout title="Notifications">
+  <div class="container mx-auto px-4 py-8">
+    <div class="flex flex-col lg:flex-row gap-8">
+      <aside class="lg:w-64 shrink-0">
+        <PortalNav currentPath={Astro.url.pathname} isAdmin={profile.role === 'admin'} />
+      </aside>
+
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center justify-between mb-6 gap-4">
+          <div>
+            <h1 class="text-3xl font-bold text-gray-900 dark:text-white">Notifications</h1>
+            <p class="text-gray-600 dark:text-gray-400 mt-1 text-sm">
+              {unread > 0 ? `${unread} unread` : 'No unread notifications'}
+            </p>
+          </div>
+          {items.length > 0 && (
+            <button
+              id="mark-all-btn"
+              class="text-sm font-medium text-clif-burgundy hover:text-clif-burgundy/80 whitespace-nowrap disabled:opacity-40 disabled:cursor-default"
+              disabled={unread === 0}
+            >
+              Mark all read
+            </button>
+          )}
+        </div>
+
+        {items.length === 0 ? (
+          <div class="bg-white dark:bg-neutral-800 rounded-xl shadow-sm border border-gray-200 dark:border-neutral-700 px-6 py-16 text-center">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.2" stroke="currentColor" class="w-12 h-12 mx-auto text-gray-300 dark:text-gray-600">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" />
+            </svg>
+            <p class="mt-4 text-gray-500 dark:text-gray-400">You have no notifications yet.</p>
+          </div>
+        ) : (
+          <ul id="notif-list" class="bg-white dark:bg-neutral-800 rounded-xl shadow-sm border border-gray-200 dark:border-neutral-700 divide-y divide-gray-100 dark:divide-neutral-700 overflow-hidden">
+            {items.map((n) => (
+              <li
+                class={`notif-row ${n.read_at ? '' : 'unread bg-clif-burgundy/[0.04] dark:bg-clif-burgundy/10'}`}
+                data-id={n.id}
+              >
+                <a
+                  href={n.link || '/portal/notifications'}
+                  class="flex items-start gap-3 px-6 py-4 hover:bg-gray-50 dark:hover:bg-neutral-700/40 transition-colors group"
+                >
+                  <span class={`mt-1.5 w-2.5 h-2.5 rounded-full shrink-0 ${n.read_at ? 'bg-transparent border border-gray-300 dark:border-neutral-600' : 'bg-clif-burgundy'}`} aria-hidden="true" />
+                  <div class="min-w-0 flex-1">
+                    <p class="text-sm font-medium text-gray-900 dark:text-gray-100 group-hover:text-clif-burgundy transition-colors">{n.title}</p>
+                    {n.body && <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{n.body}</p>}
+                    <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">{timeAgo(n.created_at)}</p>
+                  </div>
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  </div>
+
+  <script is:inline>
+    (function () {
+      // Mark an item read when clicked through.
+      document.querySelectorAll('.notif-row a').forEach(function (a) {
+        a.addEventListener('click', function () {
+          var row = a.closest('.notif-row');
+          var id = row && row.getAttribute('data-id');
+          if (!id) return;
+          var payload = JSON.stringify({ id: id });
+          navigator.sendBeacon
+            ? navigator.sendBeacon('/api/notifications/mark-read', new Blob([payload], { type: 'application/json' }))
+            : fetch('/api/notifications/mark-read', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: payload, keepalive: true });
+        });
+      });
+
+      var markAll = document.getElementById('mark-all-btn');
+      if (markAll) {
+        markAll.addEventListener('click', async function () {
+          markAll.disabled = true;
+          await fetch('/api/notifications/mark-read', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ all: true }),
+          }).catch(function () {});
+          document.querySelectorAll('.notif-row.unread').forEach(function (row) {
+            row.classList.remove('unread', 'bg-clif-burgundy/[0.04]', 'dark:bg-clif-burgundy/10');
+            var dot = row.querySelector('span[aria-hidden="true"]');
+            if (dot) dot.className = 'mt-1.5 w-2.5 h-2.5 rounded-full shrink-0 bg-transparent border border-gray-300 dark:border-neutral-600';
+          });
+        });
+      }
+    })();
+  </script>
+</BaseLayout>

--- a/src/pages/portal/project-runs.astro
+++ b/src/pages/portal/project-runs.astro
@@ -262,6 +262,54 @@ const PURPOSE_OPTIONS = Object.entries(PURPOSE_LABELS).map(([value, label]) => (
 
                     {manage && (
                       <div class="flex items-center gap-3 shrink-0">
+                        <button
+                          class={`status-project-btn inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-clif-burgundy/50 ${
+                            isClosed
+                              ? 'border border-gray-300 text-gray-700 bg-white hover:bg-gray-50 dark:border-neutral-600 dark:text-gray-200 dark:bg-neutral-800 dark:hover:bg-neutral-700'
+                              : 'bg-clif-burgundy text-white hover:bg-clif-burgundy/90'
+                          }`}
+                          data-project-id={p.id}
+                          data-next={isClosed ? 'open' : 'closed'}
+                        >
+                          {isClosed ? (
+                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                            </svg>
+                          ) : (
+                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                            </svg>
+                          )}
+                          {isClosed ? 'Reopen run' : 'Close run'}
+                        </button>
+                        <span class="group relative inline-flex">
+                          <button
+                            type="button"
+                            class="inline-flex items-center justify-center w-4 h-4 rounded-full border border-gray-400 text-gray-500 dark:border-gray-500 dark:text-gray-400 text-[10px] leading-none font-semibold hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 focus:outline-none focus:ring-2 focus:ring-clif-burgundy/50"
+                            aria-label={isClosed ? 'What reopening does' : 'What closing does'}
+                          >i</button>
+                          <span
+                            role="note"
+                            class="pointer-events-none invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 transition-opacity absolute right-0 top-full mt-2 z-20 w-72 rounded-lg bg-gray-900 dark:bg-neutral-700 text-white text-xs leading-relaxed p-3 shadow-lg text-left font-normal normal-case"
+                          >
+                            {isClosed ? (
+                              <>
+                                <strong class="block mb-1">Reopening this run</strong>
+                                Requests for runs open again — sites can submit new data for this project.
+                                Members will see it in their pending tasks again, and sites that still owe a
+                                run can be notified about it.
+                              </>
+                            ) : (
+                              <>
+                                <strong class="block mb-1">Closing this run</strong>
+                                Requests for runs are closed — sites are no longer submitting new data for
+                                this project. Members will also stop seeing it in their pending tasks, and
+                                will no longer be notified that a run is still pending at their site.
+                              </>
+                            )}
+                          </span>
+                        </span>
+                        <span class="w-px h-4 bg-gray-200 dark:bg-neutral-600" aria-hidden="true"></span>
                         <button class="notify-project-btn text-xs text-clif-burgundy hover:text-clif-burgundy/80 underline" data-project-id={p.id} title="Email all approved members that this run is ready">Notify members</button>
                         <button class="edit-project-btn text-xs text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 underline" data-project-id={p.id}>Edit</button>
                         <button class="delete-project-btn text-xs text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 underline" data-project-id={p.id}>Delete</button>
@@ -557,6 +605,35 @@ const PURPOSE_OPTIONS = Object.entries(PURPOSE_LABELS).map(([value, label]) => (
           }
           self.textContent = original;
           self.disabled = false;
+        });
+      });
+
+      // Close / reopen
+      document.querySelectorAll('.status-project-btn').forEach(function (btn) {
+        btn.addEventListener('click', async function () {
+          var pid = this.getAttribute('data-project-id');
+          var next = this.getAttribute('data-next');
+          var msg = next === 'closed'
+            ? 'Close this project run?\n\nRequests for runs will be closed — sites can no longer submit new data for this project. Members will stop seeing it in their pending tasks and will no longer be notified that a run is pending at their site.'
+            : 'Reopen this project run?\n\nSites can submit new data again, and it will return to members\' pending tasks.';
+          if (!confirm(msg)) return;
+          var self = this;
+          var original = self.textContent;
+          self.disabled = true;
+          self.textContent = next === 'closed' ? 'Closing...' : 'Reopening...';
+          var res = await fetch('/api/project-runs/set-status', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ projectId: pid, status: next }),
+          });
+          if (res.ok) {
+            window.location.reload();
+          } else {
+            var err = await res.json().catch(function () { return {}; });
+            alert(err.error || 'Failed to update status.');
+            self.textContent = original;
+            self.disabled = false;
+          }
         });
       });
 

--- a/src/pages/portal/project-runs.astro
+++ b/src/pages/portal/project-runs.astro
@@ -329,19 +329,33 @@ const PURPOSE_OPTIONS = Object.entries(PURPOSE_LABELS).map(([value, label]) => (
                         {sites.map((s) => {
                           const checked = ranSites.has(s.id as string);
                           const editable = !isClosed && editableSiteIds.has(s.id as string);
+                          // The creator (or an admin) can nudge a site that hasn't run yet.
+                          const canNudge = !isClosed && !checked && canManage(p);
                           return (
-                            <label class={`flex items-center gap-2 text-sm ${editable ? 'cursor-pointer text-gray-700 dark:text-gray-300' : 'text-gray-500 dark:text-gray-400'}`}
-                              title={editable ? '' : "Only this site's data editor (or an admin) can change this"}>
-                              <input
-                                type="checkbox"
-                                class="site-run-checkbox w-4 h-4 text-clif-burgundy border-gray-300 rounded focus:ring-clif-burgundy disabled:opacity-50"
-                                data-project-id={p.id}
-                                data-site-id={s.id}
-                                checked={checked}
-                                disabled={!editable}
-                              />
-                              <span class="truncate">{s.site_name}</span>
-                            </label>
+                            <div class="flex items-center gap-2 min-w-0">
+                              <label class={`flex items-center gap-2 text-sm min-w-0 flex-1 ${editable ? 'cursor-pointer text-gray-700 dark:text-gray-300' : 'text-gray-500 dark:text-gray-400'}`}
+                                title={editable ? '' : "Only this site's data editor (or an admin) can change this"}>
+                                <input
+                                  type="checkbox"
+                                  class="site-run-checkbox w-4 h-4 text-clif-burgundy border-gray-300 rounded focus:ring-clif-burgundy disabled:opacity-50"
+                                  data-project-id={p.id}
+                                  data-site-id={s.id}
+                                  checked={checked}
+                                  disabled={!editable}
+                                />
+                                <span class="truncate">{s.site_name}</span>
+                              </label>
+                              {canNudge && (
+                                <button
+                                  type="button"
+                                  class="nudge-site-btn shrink-0 text-[11px] font-medium text-clif-burgundy hover:text-clif-burgundy/80 hover:underline"
+                                  data-project-id={p.id}
+                                  data-site-id={s.id}
+                                  data-site-name={s.site_name}
+                                  title={`Remind ${s.site_name}'s data editor to run this project`}
+                                >Remind</button>
+                              )}
+                            </div>
                           );
                         })}
                       </div>
@@ -584,6 +598,41 @@ const PURPOSE_OPTIONS = Object.entries(PURPOSE_LABELS).map(([value, label]) => (
             var data = await res.json();
             alert(data.error || 'Failed to update');
             self.checked = !self.checked;
+            self.disabled = false;
+          }
+        });
+      });
+
+      // "Remind" — nudge a site's data editor(s) to run this project.
+      document.querySelectorAll('.nudge-site-btn').forEach(function (btn) {
+        btn.addEventListener('click', async function () {
+          var self = this;
+          var siteName = self.getAttribute('data-site-name') || 'this site';
+          if (!confirm('Send a reminder to ' + siteName + "'s data editor to run this project?")) return;
+          var original = self.textContent;
+          self.disabled = true;
+          self.textContent = 'Sending…';
+          try {
+            var res = await fetch('/api/project-runs/nudge', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                projectId: self.getAttribute('data-project-id'),
+                siteId: self.getAttribute('data-site-id'),
+              }),
+            });
+            var data = await res.json();
+            if (res.ok) {
+              self.textContent = 'Reminded ✓';
+              self.classList.add('text-green-600');
+            } else {
+              alert(data.error || 'Failed to send reminder');
+              self.textContent = original;
+              self.disabled = false;
+            }
+          } catch (e) {
+            alert('Failed to send reminder');
+            self.textContent = original;
             self.disabled = false;
           }
         });


### PR DESCRIPTION
Adds a pending-tasks panel and a notifications system to the member portal.

## Pending tasks
Derived live per request in `src/lib/tasks.ts` — nothing is stored, so a task disappears the moment its underlying state resolves. Five variants:

| Task | Trigger | Audience | Dismissible |
|---|---|---|---|
| `run_project` (action) | An open run one of your sites still owes | That site's editors | No |
| `run_project_info` | An open run you have no stake in | All approved members | No |
| `stale_site` | Required site field blank, or untouched >6 months | That site's editors | Yes |
| `incomplete_profile` | Your name / institution / work email blank | You | Yes |
| `los_review` | A pending letter-of-support request | Steering + admin | No |

Dismissals are signature-based, so a task returns if the underlying situation changes rather than being silenced permanently.

## Notifications
Stored in a `notifications` table (migration 012): `project_run.created`, `project_run.site_nudged`, `site_editor.assigned`. Badge counts unread; the bell and inbox share the same count.

## Also in this branch
- **Close / Reopen run** as a direct action on project run cards. Closing was previously only reachable as a checkbox inside the full Edit form — less discoverable than Delete — so overdue runs lingered on every member's dashboard. Backed by a dedicated one-column `set-status` endpoint rather than `/update`, which revalidates and rewrites all twelve columns.
- An info tooltip and confirm dialog spelling out what closing means: run requests close, sites stop submitting data, members stop being notified about pending runs at their site.
- **Timestamp fix.** `datetime('now')` writes `YYYY-MM-DD HH:MM:SS` with no zone, which `new Date()` read as local time, drifting the 6-month staleness window by the UTC offset. `updated_at` also has no DEFAULT and no trigger, so seeded sites carry NULL — that reached `formatDate(null)`, threw, and was swallowed by a bare `catch`, silently dropping `stale_site` tasks for *every* site a member edits.

## Verification status
`npm run build` passes on the merged tree. **The UI changes have not been exercised in a browser** — the Close/Reopen pill, its tooltip, and the merge resolution in the site-checkbox row all warrant a visual check before merging.

## Known follow-ups (not in this PR)
- `run_project_info` tasks are informational but still increment the dashboard badge, and are not dismissible — a member with no action available cannot clear them. Candidate fix: exclude `severity === 'info'` from `pendingTaskCount`.
- The four `catch { /* skip */ }` blocks in `tasks.ts` swallow errors silently; that is what hid the NULL crash above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)