### PR TITLE
fix(portal): scope the close-run tooltip to its own hover group

### DIFF
--- a/src/pages/portal/project-runs.astro
+++ b/src/pages/portal/project-runs.astro
@@ -294,8 +294,11 @@ const PURPOSE_OPTIONS = Object.entries(PURPOSE_LABELS).map(([value, label]) => (
                     {manage && (
                       <div class="flex items-center gap-3 shrink-0">
                         {/* Close button and its info marker share one hover group, so
-                            the explanation appears whenever the pointer is on either. */}
-                        <span class="group relative inline-flex items-center gap-1.5">
+                            the explanation appears whenever the pointer is on either.
+                            The group is NAMED: the whole card is a <details class="group">,
+                            and a bare group-hover: compiles to a descendant selector, so
+                            an unnamed group here would fire on hover anywhere in the card. */}
+                        <span class="group/runinfo relative inline-flex items-center gap-1.5">
                         <button
                           class={`status-project-btn inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-clif-burgundy/50 ${
                             isClosed
@@ -323,7 +326,7 @@ const PURPOSE_OPTIONS = Object.entries(PURPOSE_LABELS).map(([value, label]) => (
                           >i</button>
                           <span
                             role="note"
-                            class="pointer-events-none invisible opacity-0 group-hover:visible group-hover:opacity-100 peer-focus-visible:visible peer-focus-visible:opacity-100 transition-opacity absolute right-0 top-full mt-2 z-20 w-72 rounded-lg bg-gray-900 dark:bg-neutral-700 text-white text-xs leading-relaxed p-3 shadow-lg text-left font-normal normal-case"
+                            class="pointer-events-none invisible opacity-0 group-hover/runinfo:visible group-hover/runinfo:opacity-100 peer-focus-visible:visible peer-focus-visible:opacity-100 transition-opacity absolute right-0 top-full mt-2 z-20 w-72 rounded-lg bg-gray-900 dark:bg-neutral-700 text-white text-xs leading-relaxed p-3 shadow-lg text-left font-normal normal-case"
                           >
                             {isClosed ? (
                               <>


### PR DESCRIPTION
The "what does closing do" note appeared whenever the pointer was anywhere inside an expanded project card — over a site checkbox, the instructions block, the description — not just near the Close button.

## Cause
Each card is wrapped in `<details class="group">` (for the collapse chevron's `group-open:rotate-90`). Tailwind's `group-hover:` compiles to a **descendant** selector:

```css
.group:hover .group-hover\:visible { visibility: visible }
```

The tooltip lives inside that `<details>`, so the card's own group matched it. Hovering the card *anywhere* revealed the note.

This is why the previous two attempts didn't fix it — adding an inner unnamed `group` can't help when an ancestor group matches the same descendant selector.

## Fix
Use a named group: `group/runinfo` on the Close-button cluster, `group-hover/runinfo:` on the note. That binds the reveal to the cluster alone.

Verified in the built CSS:
- emits `.group\/runinfo:hover .group-hover\/runinfo\:visible`
- no unscoped `.group:hover` rule targets the note

## History
Third PR on this tooltip. #22 and #23 fixed real but secondary problems (a click-pinned `focus-within` state); the card-wide hover trigger went unnoticed because I kept reasoning about the markup I had added rather than the markup it sat inside. Confirmed working by the user against a fresh dev server before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)