### PR TITLE
docs(data-dictionary): record dropping glucose_serum from lab_category in 3.0

### DIFF
--- a/src/pages/data-dictionary/change-log.astro
+++ b/src/pages/data-dictionary/change-log.astro
@@ -502,7 +502,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
                       <li><strong>Urine chemistry</strong> (2): <code>albumin_to_creatinine_ratio</code>, <code>protein_to_creatinine_ratio</code></li>
                       <li><strong>Thyroid</strong> (3): <code>free_t3</code>, <code>free_t4</code>, <code>tsh</code></li>
                       <li><strong>Coagulation</strong> (2): <code>d_dimer</code>, <code>fibrinogen</code></li>
-                      <li><strong>POC / bedside</strong> (3): <code>co2</code>, <code>glucose</code> (replaces <code>glucose_fingerstick</code>), <code>hematocrit</code></li>
+                      <li><strong>POC / bedside</strong> (3): <code>co2</code>, <code>glucose</code> (replaces both <code>glucose_fingerstick</code> and <code>glucose_serum</code>), <code>hematocrit</code></li>
                       <li><strong>Mixed-venous blood gas</strong> (1): <code>po2_mixed_venous</code></li>
                       <li><strong>Misc</strong> (1): <code>triglycerides</code></li>
                     </ul>
@@ -526,7 +526,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
           <summary
             class="cursor-pointer bg-clif-burgundy/5 px-4 py-3 font-semibold text-clif-burgundy hover:bg-clif-burgundy/10 transition-colors"
           >
-            Revisions (14 updates) <span class="text-sm font-normal text-gray-600 ml-2">Last updated: Jun 30, 2026</span>
+            Revisions (15 updates) <span class="text-sm font-normal text-gray-600 ml-2">Last updated: Jul 21, 2026</span>
           </summary>
           <div class="overflow-x-auto">
             <table class="min-w-full divide-y divide-gray-200">
@@ -547,6 +547,12 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
                 </tr>
               </thead>
               <tbody class="bg-white divide-y divide-gray-200">
+                <tr>
+                  <td class="px-4 py-3 text-sm font-mono">labs.lab_category</td>
+                  <td class="px-4 py-3 text-sm">Dropped <code>glucose_serum</code> from the <code>labs.lab_category</code> mCIDE. <code>glucose</code> replaces both <code>glucose_serum</code> and <code>glucose_fingerstick</code>, with the specimen distinguished by <code>lab_specimen_category</code> and the panel by <code>lab_order_category</code> — the same de-prefixing convention applied to the other source-specific labs in 3.0.</td>
+                  <td class="px-4 py-3 text-sm text-gray-500">&mdash;</td>
+                  <td class="px-4 py-3 text-sm text-gray-500">Jul 21, 2026</td>
+                </tr>
                 <tr>
                   <td class="px-4 py-3 text-sm font-mono">patient_procedures</td>
                   <td class="px-4 py-3 text-sm">Clarified that <code>patient_procedures</code> should ETL <strong>all</strong> CPT codes (HCPCS Level 1), including CPT codes recorded in hospital billing encounters (e.g., PT/OT codes) — not only clinician/professional billing codes. HCPCS Level 2 products and supplies remain excluded.</td>


### PR DESCRIPTION
Adds a 3.0 change-log revision recording that `glucose_serum` is dropped from the `labs.lab_category` mCIDE.

`glucose` replaces both `glucose_serum` and `glucose_fingerstick`, with the specimen distinguished by `lab_specimen_category` and the panel by `lab_order_category` — the same de-prefixing convention already applied to the other source-specific labs in 3.0.

## Changes
- New **Revisions** row dated Jul 21 2026, placed at the top of the 3.0 section (rows are reverse-chronological).
- Revisions header recounted **14 → 15**, "Last updated" moved to Jul 21 2026.
- The **New mCIDE Values** row for POC / bedside previously said `glucose` "replaces `glucose_fingerstick`" — it now names `glucose_serum` too, so the two statements can't disagree.

## Counts left unchanged, deliberately
Dropping a permissible value adds none, so the mCIDE header stays at *17 updates · 240 new values*, and the `lab_category (56)` sub-bullets still sum to 56. Verified the Revisions header matches its 15 data rows.

## Propagation
The 3.0 DDL, markdown doc, page table groupings, ERD and `table-poc.json` contain no `glucose` reference — this is an mCIDE value, not a table or field — so nothing propagates there. `npm run build` passes.

## Known gap, not addressed here
`public/data/mcide/` still serves `glucose_serum` as a live concept (2 hits in `mcide_concepts.json`, 2 in `mcide_graph.json`, 9 in `mcide_synonyms.json`), fetched at runtime by `/mcide-explorer`. So the change log will say it's dropped while the explorer still offers it.

The synonyms are also split across two now-dead values, with no `glucose` concept existing at all:

```
glucose_fingerstick -> BLOOD SUGAR, BLOOD GLUCOSE, GLUCOSE
glucose_serum       -> BLOOD SUGAR, BLOOD GLUCOSE, GLUCOSE
```

Fixing that means creating a `glucose` concept, moving the synonyms onto it, and removing both old entries from all three files. Left out because it changes how sites map their local labs, and it's unclear whether these files are hand-maintained or synced from the upstream CLIF mCIDE repo — if synced, an edit here would be overwritten.

The Status cell uses the existing linkless `—` convention rather than an invented issue number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)